### PR TITLE
feat: CLIN-1427 - revert spark image 3.1.2

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -32,7 +32,7 @@ fhir_csv_image = 'ferlabcrsj/csv-to-fhir'
 fhir_image = 'ferlabcrsj/clin-fhir'
 pipeline_image = 'ferlabcrsj/clin-pipelines'
 postgres_image = 'ferlabcrsj/postgres-backup:9bb43092f76e95f17cd09f03a27c65d84112a3cd'
-spark_image = 'ferlabcrsj/spark:edbf8efb3cc40e63b5204c62ae246487ce76db1a'
+spark_image = 'ferlabcrsj/spark:3.1.2'
 spark_service_account = 'spark'
 
 if env == Env.QA:


### PR DESCRIPTION
We can rollback to this version. The important changes has been done in prod repo inside the executors configs like this: https://github.com/Ferlab-Ste-Justine/cqgc-prod-kubernetes-environments/blob/main/prod/apps/spark-jobs/index-elasticsearch-etl/configs.yml#L11