### PR TITLE
fix: CLIN-1872 no_dup_snv sur service_request_id

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -41,7 +41,7 @@ if env == Env.QA:
     fhir_image = 'ferlabcrsj/clin-fhir'
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 's3a://cqgc-qa-app-datalake/jars/clin-variant-etl-v2.7.4.jar'
+    spark_jar = 's3a://cqgc-qa-app-datalake/jars/clin-variant-etl-v2.7.5.jar'
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'
 elif env == Env.STAGING:

--- a/dags/lib/doc/qa.py
+++ b/dags/lib/doc/qa.py
@@ -59,7 +59,7 @@ no_dup_gnomad = '''
 no_dup_snv = '''
 ### Documentation
 - Test : Non duplication - Table normalized_snv
-- Objectif : Les variants doivent être unique par patient_id dans la table normalized_snv
+- Objectif : Les variants doivent être unique par service_request_id dans la table normalized_snv
 '''
 
 no_dup_nor_consequences = '''


### PR DESCRIPTION
Les variants de la table normalized_snv doivent être unique par service_request_id et non par patient_id