### PR TITLE
Feat/1997 custom spark jar

### DIFF
--- a/dags/etl_ingest.py
+++ b/dags/etl_ingest.py
@@ -23,6 +23,7 @@ with DAG(
         'batch_id': Param('', type='string'),
         'color': Param('', enum=['', 'blue', 'green']),
         'import': Param('yes', enum=['yes', 'no']),
+        'spark_jar': Param('', type='string'),
     },
     default_args={
         'trigger_rule': TriggerRule.NONE_FAILED,
@@ -32,6 +33,9 @@ with DAG(
 
     def batch_id() -> str:
         return '{{ params.batch_id }}'
+
+    def spark_jar() -> str:
+        return '{{ params.spark_jar }}'
 
     def color(prefix: str = '') -> str:
         return '{% if params.color|length %}' + prefix + '{{ params.color }}{% endif %}'
@@ -65,6 +69,7 @@ with DAG(
         color=color(),
         skip_import=skip_import(),  # skipping already imported batch is allowed
         skip_batch='', # always compute this batch (purpose of this dag)
+        spark_jar=spark_jar(),
     )
 
     slack = EmptyOperator(

--- a/dags/etl_qa.py
+++ b/dags/etl_qa.py
@@ -16,6 +16,7 @@ with DAG(
     schedule_interval=None,
     params={
         'release_id': Param('', type='string'),
+        'spark_jar': Param('', type='string'),
     },
     default_args={
         'trigger_rule': TriggerRule.NONE_FAILED,
@@ -24,6 +25,9 @@ with DAG(
 
     def release_id() -> str:
         return '{{ params.release_id }}'
+
+    def spark_jar() -> str:
+        return '{{ params.spark_jar }}'
 
     def _params_validate(release_id):
         if release_id == '':
@@ -39,6 +43,7 @@ with DAG(
     qa = qa(
         group_id='qa',
         release_id=release_id(),
+        spark_jar=spark_jar(),
     )
 
     slack = EmptyOperator(

--- a/dags/etl_qc.py
+++ b/dags/etl_qc.py
@@ -17,6 +17,7 @@ with DAG(
     schedule_interval=None,
     params={
         'release_id': Param('', type='string'),
+        'spark_jar': Param('', type='string'),
     },
     default_args={
         'trigger_rule': TriggerRule.NONE_FAILED,
@@ -25,6 +26,9 @@ with DAG(
 
     def release_id() -> str:
         return '{{ params.release_id }}'
+
+    def spark_jar() -> str:
+        return '{{ params.spark_jar }}'
 
     def _params_validate(release_id):
         if release_id == '':
@@ -40,6 +44,7 @@ with DAG(
     qc = qc(
         group_id='qc',
         release_id=release_id(),
+        spark_jar=spark_jar(),
     )
 
     slack = EmptyOperator(

--- a/dags/lib/groups/ingest.py
+++ b/dags/lib/groups/ingest.py
@@ -75,6 +75,18 @@ def ingest(
             ],
         )
 
+        snv_somatic = SparkOperator(
+            task_id='snv_somatic',
+            name='etl-ingest-snv-somatic',
+            k8s_context=K8sContext.ETL,
+            spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
+            spark_config='raw-vcf-etl',
+            skip=skip_batch,
+            arguments=[
+                f'config/{env}.conf', 'default', batch_id, 'snv_somatic',
+            ],
+        )
+
         cnv = SparkOperator(
             task_id='cnv',
             name='etl-ingest-cnv',
@@ -139,6 +151,6 @@ def ingest(
         )
         '''
 
-        fhir_import >> fhir_export >> fhir_normalize >> snv >> cnv >> variants >> consequences >> exomiser
+        fhir_import >> fhir_export >> fhir_normalize >> snv >> snv_somatic >> cnv >> variants >> consequences >> exomiser
 
     return group

--- a/dags/lib/groups/ingest.py
+++ b/dags/lib/groups/ingest.py
@@ -23,6 +23,7 @@ def ingest(
     color: str,
     skip_import: str,
     skip_batch: str,
+    spark_jar: str,
 ) -> TaskGroup:
 
     with TaskGroup(group_id=group_id) as group:
@@ -58,6 +59,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.fhir.FhirRawToNormalized',
             spark_config='raw-fhir-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'initial', 'all',
             ],
@@ -70,6 +72,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'snv',
             ],
@@ -82,6 +85,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'snv_somatic',
             ],
@@ -94,6 +98,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'cnv',
             ],
@@ -106,6 +111,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'variants',
             ],
@@ -118,6 +124,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'consequences',
             ],
@@ -130,6 +137,7 @@ def ingest(
             spark_class='bio.ferlab.clin.etl.normalized.RunNormalized',
             spark_config='raw-vcf-etl',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', batch_id, 'exomiser',
             ],
@@ -144,6 +152,7 @@ def ingest(
             spark_config='varsome-etl',
             spark_secret='varsome',
             skip=skip_batch,
+            spark_jar=spark_jar,
             arguments=[
                 f'config/{env}.conf', 'default', 'all', batch_id
             ],

--- a/dags/lib/groups/qa.py
+++ b/dags/lib/groups/qa.py
@@ -7,6 +7,7 @@ from lib.operators.spark import SparkOperator
 def qa(
     group_id: str,
     release_id: str,
+    spark_jar: str,
 ) -> TaskGroup:
 
     with TaskGroup(group_id=group_id) as group:
@@ -18,6 +19,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.tables.NonEmptyTables',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -29,6 +31,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationGnomad',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -40,6 +43,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationNorSNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -51,6 +55,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationNorConsequences',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -62,6 +67,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationNorVariants',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -73,6 +79,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationSNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -84,6 +91,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationConsequences',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -95,6 +103,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationVariants',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -106,6 +115,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationVariantCentric',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -117,6 +127,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationCNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -128,6 +139,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.NonDuplicationVarsome',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -139,6 +151,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.SameListBetweenNorSNVAndNorVariants',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -150,6 +163,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.SameListBetweenSNVAndVariants',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -161,6 +175,7 @@ def qa(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantlist.SameListBetweenVariantsAndVariantCentric',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )

--- a/dags/lib/groups/qc.py
+++ b/dags/lib/groups/qc.py
@@ -7,6 +7,7 @@ from lib.operators.spark import SparkOperator
 def qc(
     group_id: str,
     release_id: str,
+    spark_jar: str,
 ) -> TaskGroup:
 
     with TaskGroup(group_id=group_id) as group:
@@ -18,6 +19,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.fromVCF.ContainedInSNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -29,6 +31,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.fromVCF.ContainedInNorVariants',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -40,6 +43,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantfilter.FiltersSNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -51,6 +55,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantfilter.FiltersFrequencyExtra',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -62,6 +67,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.variantfilter.FiltersFrequencyMissed',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -73,6 +79,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainNoNullVariantCentric',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -84,6 +91,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainNoNullGene',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -95,6 +103,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainNoNullCNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -106,6 +115,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainOnlyNullVariantCentric',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -117,6 +127,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainOnlyNullGene',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -128,6 +139,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainOnlyNullCNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -139,6 +151,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainSameValueVariantCentric',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -150,6 +163,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainSameValueGene',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -161,6 +175,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.columncontain.ColumnsContainSameValueCNV',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -172,6 +187,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.varsome.VariantsShouldBeAnnotated',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -183,6 +199,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.varsome.VariantsShouldNotBeAnnotated',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -194,6 +211,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.varsome.VariantsShouldBeReannotated',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -205,6 +223,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.varsome.VariantsShouldNotBeReannotated',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -217,6 +236,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.RQDMTotal',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -228,6 +248,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.RQDMAffected',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -239,6 +260,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.RQDMNonAffected',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -250,6 +272,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.ByAnalysisTotal',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -261,6 +284,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.ByAnalysisAffected',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )
@@ -272,6 +296,7 @@ def qc(
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.qc.frequency.ByAnalysisNonAffected',
             spark_config='enriched-etl',
+            spark_jar=spark_jar,
             arguments=['clin' + env_url('_'), release_id],
             skip_fail_env=[Env.QA, Env.STAGING, Env.PROD],
         )

--- a/dags/test_spark_fail.py
+++ b/dags/test_spark_fail.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from lib import config
 from lib.config import env, K8sContext
 from lib.operators.spark import SparkOperator
-
+from airflow.models.param import Param
 
 if (config.show_test_dags):
 
@@ -11,13 +11,20 @@ if (config.show_test_dags):
         dag_id='test_spark_fail',
         start_date=datetime(2022, 1, 1),
         schedule_interval=None,
+        params={
+            'spark_jar': Param('', type='string'),
+        },
     ) as dag:
 
+        def spark_jar() -> str:
+            return '{{ params.spark_jar }}'
+            
         test_spark_fail = SparkOperator(
             task_id='test_spark_fail',
             name='test-spark-fail',
             k8s_context=K8sContext.ETL,
             spark_class='bio.ferlab.clin.etl.fail.Fail',
             spark_config='enriched-etl',
+            spark_jar=spark_jar(),
             arguments=[f'config/{env}.conf', 'default'],
         )


### PR DESCRIPTION
Add new optional param for ETL dags to help test JAR while PR is in review/open
- build local JAR and use `deploy.sh` to put them on S3
- avoid create a tag from `master/main` again and again while testing
- optional, if missing will use `config.py` as usual

```
{
...
    "spark_jar": "v2.10.0-my-custom-dev-feature",
...
}
```
