### PR TITLE
chore: CLIN-2182 Set import gene census to initial

### DIFF
--- a/dags/etl_import_cosmic.py
+++ b/dags/etl_import_cosmic.py
@@ -46,12 +46,13 @@ with DAG(
         latest_ver = re.search('COSMIC (v[0-9]+),', html).group(1)
         logging.info(f'COSMIC latest version: {latest_ver}')
 
-        gene_census_file = 'cancer_gene_census.csv'
+        # TODO: Download Cosmic_CancerGeneCensus_GRCh38.tar when scripted downloads are added to new download page
+        # gene_census_file = 'cancer_gene_census.csv'
         mutation_census_file = 'cmc_export.tsv.gz'
         mutation_census_archive = 'CMC.tar'
         updated = False
 
-        for file_name in [gene_census_file, mutation_census_file]:
+        for file_name in [mutation_census_file]:
             s3_key = f'raw/landing/cosmic/{file_name}'
 
             # Get imported version
@@ -104,7 +105,7 @@ with DAG(
         arguments=[
             'cosmic_gene_set',
             '--config', config_file,
-            '--steps', 'default',
+            '--steps', 'initial',
             '--app-name', 'etl_import_cosmic_gene_set_table',
         ],
         trigger_rule=TriggerRule.NONE_FAILED

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -42,7 +42,7 @@ if env == Env.QA:
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 's3a://cqgc-qa-app-datalake/jars/clin-variant-etl-v2.16.3.jar'
+    spark_jar = 's3a://cqgc-qa-app-datalake/jars/clin-variant-etl-v2.17.0.jar'
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'
     indexer_context = K8sContext.DEFAULT


### PR DESCRIPTION
Le fichier téléchargé automatiquement pour cosmic_gene n'était pas le bon. Le fichier adéquat est seulement disponible en téléchargement manuel pour le moment. J'ai donc désactivé le téléchargement automatique de ce fichier. Il faut aussi rouler la job d'import en initial pour nettoyer le schéma de l'ancien fichier qui était erroné.