### PR TITLE
feat: CLIN-3138 Add nextflow test dag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs
 plugins
 venv
 .idea
+doc/test/.minikube-setup

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -37,17 +37,27 @@ cosmic_credentials = Variable.get('cosmic_credentials', None)
 topmed_bravo_credentials = Variable.get('topmed_bravo_credentials', None)
 basespace_illumina_credentials = Variable.get('basespace_illumina_credentials', None)
 
+clin_import_bucket = f'cqgc-{env}-app-files-import'
+clin_datalake_bucket = f'cqgc-{env}-app-datalake'
+clin_scratch_bucket = f'cqgc-{env}-app-files-scratch'
+
 arranger_image = 'ferlabcrsj/clin-arranger:1.3.3'
 aws_image = 'amazon/aws-cli'
 curl_image = 'curlimages/curl'
 fhir_csv_image = 'ferlabcrsj/csv-to-fhir'
 postgres_image = 'ferlabcrsj/postgres-backup:9bb43092f76e95f17cd09f03a27c65d84112a3cd'
+nextflow_image = 'nextflow/nextflow:23.10.1'
+nextflow_service_account = 'nextflow'
+nextflow_config_map = 'nextflow'
+nextflow_minio_secret = f'cqgc-{env}-minio-app-nextflow'
+nextflow_minio_access_key_property = 'access_key'
+nextflow_minio_secret_key_property = 'secret_key'
+nextflow_pvc = f'cqgc-{env}-nextflow-pvc'
+nextflow_pv_sub_path = 'workspace'
+nextflow_working_dir = f's3://{clin_scratch_bucket}/nextflow/scratch'
 spark_image = 'ferlabcrsj/spark:65d1946780f97a8acdd958b89b64fad118c893ee'
 spark_service_account = 'spark'
 batch_ids = []
-
-clin_import_bucket = f'cqgc-{env}-app-files-import'
-clin_datalake_bucket = f'cqgc-{env}-app-datalake'
 
 if env == Env.QA:
     fhir_image = 'ferlabcrsj/clin-fhir'

--- a/dags/lib/operators/nextflow.py
+++ b/dags/lib/operators/nextflow.py
@@ -1,0 +1,139 @@
+import logging
+from pathlib import Path
+import re
+
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+
+from lib import config
+from lib.operators.utils import utils_pod
+
+logger = logging.getLogger(__name__)
+
+class NextflowOperator(KubernetesPodOperator):
+    """
+    Custom operator to run nextflow within a kubernetes pod. 
+    
+    See `test_nextflow_operator.py` for an usage example.
+
+    Nextflow is launched within a persistent volume to ensure the persistence of logs, checkpoints, and history 
+    files. Each execution gets a unique launch directory to avoid conflicts. The pod's working directory is 
+    set to this launch directory.
+
+    Minio credentials are provided via a Kubernetes secret, and nextflow configuration file(s) are injected 
+    through a Kubernetes configmap, mounted at `/root/nextflow/config/`.
+    """
+    def __init__(
+        self,
+        k8s_context: str,
+        **kwargs
+    ) -> None:
+        super().__init__(
+            is_delete_operator_pod=True,
+            in_cluster=config.k8s_in_cluster(k8s_context),
+            config_file=config.k8s_config_file(k8s_context),
+            cluster_context=config.k8s_cluster_context(k8s_context),
+            namespace=config.k8s_namespace,
+            image=config.nextflow_image,
+            service_account_name=config.nextflow_service_account,
+            **kwargs
+        )
+
+        self.config_map_name = config.nextflow_config_map
+        self.minio_secret_name = config.nextflow_minio_secret
+        self.minio_access_key_property = config.nextflow_minio_access_key_property
+        self.minio_secret_key_property = config.nextflow_minio_secret_key_property
+        self.persistent_volume_claim_name = config.nextflow_pvc
+        self.persistent_volume_sub_path = config.nextflow_pv_sub_path
+
+        # Where nextflow will write intermediate outputs. This is different from the launch directory,
+        # i.e. where the nextflow command is executed.
+        self.nextflow_working_dir = config.nextflow_working_dir
+     
+
+    def execute(self, context, **kwargs):
+        persistent_volume_mount_path = "/mnt/workspace"
+    
+        self.env_vars = [
+            k8s.V1EnvVar(
+                name="AWS_ACCESS_KEY_ID",
+                value_from=k8s.V1EnvVarSource(
+                    secret_key_ref=k8s.V1SecretKeySelector(
+                        name=self.minio_secret_name,
+                        key=self.minio_access_key_property
+                    ),
+                ),
+            ),
+            k8s.V1EnvVar(
+                name="AWS_SECRET_ACCESS_KEY",
+                value_from=k8s.V1EnvVarSource(
+                    secret_key_ref=k8s.V1SecretKeySelector(
+                        name=self.minio_secret_name,
+                        key=self.minio_secret_key_property
+                    ),
+                ),
+            ),
+            k8s.V1EnvVar(
+                name="NXF_WORK",
+                value=self.nextflow_working_dir
+            ),
+           
+            k8s.V1EnvVar(
+                name="NXF_EXECUTOR",
+                value="k8s"
+            )
+        ]
+        
+        self.volumes = [
+            k8s.V1Volume(
+                name='nextflow-config',
+                config_map=k8s.V1ConfigMapVolumeSource(
+                    name=self.config_map_name
+                ),
+            ),
+            k8s.V1Volume(
+                name='nextflow-workspace',
+                persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name=self.persistent_volume_claim_name)
+            )
+        ]
+
+        self.volume_mounts = [
+            k8s.V1VolumeMount(
+                name='nextflow-config',
+                mount_path='/root/nextflow/config',
+                read_only=True,
+            ),
+            k8s.V1VolumeMount(
+                name='nextflow-workspace',
+                mount_path= persistent_volume_mount_path,
+                sub_path=self.persistent_volume_sub_path
+            )
+        ]
+
+        # As far as we know, the KubernetesPodOperator does not provide a direct attribute to set the working
+        # directory. Therefore, we configure it within the container specification in attribute full_pod_spec.
+        pod_working_dir = _get_pod_working_dir(persistent_volume_mount_path, context)
+        logger.info("Setting pod working directory to %s", pod_working_dir)
+        self.full_pod_spec = utils_pod.add_working_dir_to_pod_spec(
+            pod_working_dir,
+            existing_pod_spec=self.full_pod_spec, 
+            container_name=self.base_container_name
+        )
+
+        super().execute(context, **kwargs)
+
+
+## Helper functions
+
+def _get_pod_working_dir(base_path, context):
+    ti = context["ti"] # the task instance
+    sanitized_run_id = _sanitize_run_id(context["run_id"])
+
+    # Will be empty for non-map tasks
+    map_index_part = f"_{ti.map_index}" if ti.map_index >= 0 else ""
+
+    return f"{base_path}/{ti.dag_id}/{ti.task_id}{map_index_part}/{sanitized_run_id}_trial{ti.try_number}"
+
+# Remove characters `+` and `:` from the run id
+def _sanitize_run_id(run_id):
+    return re.sub(r'[+:]', '', run_id)

--- a/dags/lib/operators/spark.py
+++ b/dags/lib/operators/spark.py
@@ -9,6 +9,7 @@ from kubernetes.client import models as k8s
 from lib import config
 from lib.config import env
 
+logger = logging.getLogger(__name__)
 
 class SparkOperator(KubernetesPodOperator):
 

--- a/dags/lib/operators/utils/utils_pod.py
+++ b/dags/lib/operators/utils/utils_pod.py
@@ -1,0 +1,36 @@
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
+from kubernetes.client import models as k8s
+
+
+def add_working_dir_to_pod_spec(working_dir, existing_pod_spec=None, container_name=None):
+    """
+    Adds a working directory to the pod specification.
+
+    Parameters:
+    working_dir (str): The working directory to set in the pod.
+    container_name (str): The name of the container to set the working directory for.
+    existing_pod_spec (k8s.V1PodSpec, optional): An existing pod specification to reconcile with.
+
+    Returns:
+    k8s.V1PodSpec: The reconciled pod specification.
+    """
+    if container_name is None:
+        if existing_pod_spec and existing_pod_spec.containers:
+            container_name = existing_pod_spec.containers[0].name
+        else:
+            container_name = KubernetesPodOperator.BASE_CONTAINER_NAME
+    pod_spec = k8s.V1Pod(
+        spec=k8s.V1PodSpec(
+            containers=[
+                k8s.V1Container(
+                    name=container_name,
+                    working_dir=working_dir
+                )
+            ]
+        )
+    )
+
+    # Reconcile the new pod spec with the existing one, if provided
+    return PodGenerator.reconcile_pods(pod_spec, existing_pod_spec)
+

--- a/dags/test_nextflow_operator.py
+++ b/dags/test_nextflow_operator.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+
+from lib import config
+from lib.config import env, Env, K8sContext
+from lib.operators.nextflow import NextflowOperator
+from lib.slack import Slack
+
+DEFAULT_NEXTFLOW_COMMAND = [
+    "nextflow",
+    "run",
+    "nextflow-io/hello",
+    "-c",
+    "/root/nextflow/config/nextflow.config"
+]
+if (config.show_test_dags or env in [Env.QA, Env.STAGING]):
+    with DAG(
+        dag_id="test_nextflow_operator",
+        start_date=datetime(2022, 1, 1),
+        schedule=None,
+        description="Run an ad-hoc nextflow command in a kubernetes pod.",
+        params={
+        "nextflow_command": Param( 
+              DEFAULT_NEXTFLOW_COMMAND, 
+              type="array", 
+              description=f"""The nextflow command to be executed. 
+              This should be expressed as a list of arguments, which will be passed to the bash shell in the nextflow pod. 
+              Here each line represent a separate argument.  
+
+              Here the `/root/nextflow/config/nextflow.config` file is a valid nextflow configuration file that will be available in the pod. 
+              It contains configuration settings specific to the Qlin execution environment. 
+              You should always include it in your nextflow command, unless you have a valid reason not to.
+
+              The nextflow working directory is set to `{config.nextflow_working_dir}`. You can overwrite it via the `-work-dir` option, 
+              but please use a location under this directory.
+           """
+           )
+       }
+    ) as dag:
+        
+        NextflowOperator(
+            task_id='test_nextflow_operator',
+            name="test_nextflow_operator", # prefix for the pod name
+            k8s_context = K8sContext.ETL,
+            arguments =  dag.params["nextflow_command"],
+            on_execute_callback=Slack.notify_dag_start,
+            on_success_callback=Slack.notify_dag_completion,
+        )

--- a/doc/test/docker_compose_and_minikube_setup.md
+++ b/doc/test/docker_compose_and_minikube_setup.md
@@ -1,0 +1,51 @@
+# Test setup with docker-compose and minikube
+
+This document describes how to use the KubernetesPodOperator with minikube for local testing.
+
+Airflow is still deployed with the celery executor with docker-compose as describe in the readme. The KubernetesPodOperator tasks are submitted to a minikube kubernetes cluster running locally.
+
+If you would prefer to deploy the full ETL, including airflow, in the minikube cluster, see `minikube_setup.md`.
+
+So far, this procedure has been tried with minikube v1.32.0 on mac os with a naïve task. More work might be necessary to ensure that it works with other linux distributions and more complex tasks.
+
+## Procedure
+
+Start minikube:
+```
+minikube start  --embed-certs  --apiserver-names=host.docker.internal  --memory=max --cpus=max 
+```
+
+Since we pass the `--embed-certs` option, the certificates will be included directly in the `kubectl` configuration file. This is important for the next steps. The  `--apiserver-names=host.docker.internal` option will allow 
+docker containers to interact with the cluster.
+
+You might want to use more restrictive values for the memory and CPU options. The default values might not be sufficient, as the minikube cluster will operate within a single Docker container. Insufficient memory and CPU resources for this container can lead to unstable behavior.
+
+Create the cqgc-qa namespace on the minikube cluster:
+```
+kubectl create namespace cqgc-qa
+```
+
+Extract the minikube config and modify it slightly to change the hostname `127.0.0.1` to `host.docker.internal`:
+```
+mkdir -p doc/test/.minikube-setup
+kubectl config view --minify --flatten --context=minikube | sed "s/127.0.0.1/host.docker.internal/g"  >doc/test/.minikube-setup/kube_config
+```
+
+Note that, when creating the minikube cluster with the `minikube start` command, minikube will generate new certificates by default. You will need to re-run this command if you delete and re-create the minikube cluster.
+
+Create your .env file as instructed in the readme. Set the variable `KUBE_CONFIG` to match the config file that you created:
+```
+KUBE_CONFIG=./doc/test/.minikube-setup/kube_config
+```
+
+Run `docker-compose up -d` and create the variables in the UI, as describe in the README. Use the value `minikube` for variables
+`kubernetes_context_default` and `kubernetes_context_etl`
+
+
+You are ready to test a simple dag. You can try dags `test_pod_operator_etl` or `test_pod_operator_default`.
+
+
+## Clean up
+
+You can simply run the command `minikube delete` to destroy the minikube cluster.
+To shut down airflow, you can run `docker-compose down`

--- a/doc/test/minikube_setup.md
+++ b/doc/test/minikube_setup.md
@@ -1,0 +1,74 @@
+# Test setup with minikube
+
+This document describes a procedure to test the airflow ETL locally with minikube, where all components, including airflow, will run as pods in a minikube cluster.
+
+This setup is particularly useful if you'd like to locally test an operator extending the `KubernetesPodOperator`. Alternatively, you can deploy airflow via docker compose and use the minikube cluster only for operators running as kubernetes pods. If you prefer this setup, see `docker_compose_and_minikube_setup.md`.
+
+To simplify the installation procedure, we use the in-cluster mode to connect to the Kubernetes cluster for operators based on the KubernetesPodOperator class. This means that cluster connection settings will be retrieved from the cluster in which airflow is deployed (i.e. minikube here).
+
+Unlike the docker-compose setup, we are not using minio to store airflow logs. We simply use a persistent volume created automatically on the minikube container.
+
+So far, this procedure has been tried with minikube v1.32.0 on mac os with a naïve task. More work might be necessary to ensure that it works with other linux distributions and more complex tasks.
+
+
+## Prerequisites
+
+- docker
+- kubectl
+- minikube
+- helm
+
+
+## Procedure
+
+First create the minikube cluster.
+
+```
+minikube start  --memory=max --cpus=max
+```
+
+Create the cqgc-qa namespace:
+
+```
+kubectl create namespace cqgc-qa
+```
+
+Install persistent volume and associated claim for dags:
+
+```
+kubectl apply -f doc/test/templates/airflow/airflow.yaml -n cqgc-qa
+```
+
+
+Mount the `dags`folder in the persistent volume.  The following command will start the minikube mount process in the background and store the PID in the file `dags_mount_pid`. To kill the process, use `kill <pid>` with the stored PID.
+```
+mkdir -p doc/test/.minikube-setup/pids
+minikube mount ./dags:/mnt/cqgc-qa/airflow/dags & echo $! >doc/test/.minikube-setup/pids/dags_mount_pid
+```
+
+Install airflow with helm:
+
+```
+# Add the airflow helm repository. This only need to be done once.
+helm repo add apache-airflow https://airflow.apache.org
+
+# Then install airflow in the minikube cluster:
+helm upgrade --install airflow apache-airflow/airflow --version 1.11.0 --namespace cqgc-qa --values doc/test/templates/airflow/values.yaml
+```
+
+Wait that all pods are ready and use the following command to access the airflow UI:
+
+```
+kubectl port-forward svc/airflow-webserver 50080:8080 --namespace cqgc-qa & echo $! >doc/test/.minikube-setup/pids/airflow_server_pid
+```
+
+Open your browser and go to the airflow login page at localhost:50080. You can enter `admin` as username and password.
+
+You can run dags `test_pod_operator_default` and `test_pod_operator_etl` to check that all is ok.
+
+The airflow variables, typically created via the Airflow UI (Admin => Variables), should be pre-created. These variables will not appear in the UI. You can view the configured values in the `test/templates/airflow/values.yaml` file (see the `env` section). If necessary, you can overwrite these values via the Airflow UI.
+
+
+## Clean up
+
+You can simply run the command `minikube delete` to destroy the minikube cluster. 

--- a/doc/test/nextflow_setup.md
+++ b/doc/test/nextflow_setup.md
@@ -1,0 +1,68 @@
+# Nextflow setup
+
+This guide describes the local minikube setup procedure common to most DAGs based on the nextflow operator. Additional steps or tweaks may be required depending on the specific DAG.
+
+## Procedure
+
+1. **Install and configure airflow on minikube** 
+
+    Choose one of the following procedures:
+    - [Docker Compose and Minikube Setup](./docker_compose_and_minikube_setup.md)
+    - [Minikube Setup](./minikube_setup.md)
+
+2. **Install and setup minio**
+
+    We use an S3 bucket (minio) to store intermediate files when running nextflow jobs. Here, 
+    we start a local minio service and create the necessary buckets.
+
+    First create required storage resources, i.e. a persistent volume and the associated claim.
+    ```
+    kubectl apply -f doc/test/templates/nextflow/minio_pv.yaml -n cqgc-qa
+    ```
+
+    Then create minio pod(s) and service(s):
+    ```
+    kubectl apply -f doc/test/templates/nextflow/mock_minio.yaml -n cqgc-qa
+    ```
+
+    Run the following command to access the minio UI:
+    ```
+    mkdir -p doc/test/.minikube-setup/nextflow/pids
+    kubectl port-forward svc/minio 9091:9091 -n cqgc-qa & echo $! >doc/test/.minikube-setup/nextflow/pids/minio_service_pid
+    ```
+
+    Login with username `minio` and password `minio123`. Through the UI, create buckets `cqgc-qa-app-files-import` and `cqgc-qa-app-files-scratch`.
+
+    By default, we assume that you are ok with using the minio admin credentials later to access minio and manipulate these buckets. If this is not acceptable, you can create the desired credentials and permissions through the UI as well. Make sure to save a copy of the created credentials, as we will need to inject them as a secret in the minikube cluster.
+
+4. **Create minio credentials secrets**
+
+This will inject minio admin credentials in a kubernetes secret that will be used to inject the credentials on the nextflow pod:
+```
+ kubectl create secret generic cqgc-qa-minio-app-nextflow --from-literal=access_key=minio --from-literal=secret_key=minio123 -n cqgc-qa
+ ```
+
+If you created credentials at step 2, replace `minio` and `minio123` values above by the access and secret keys that you created.
+
+
+5. **Create other required nextflow resources**
+
+    ```bash
+    # Create config map that will be used to inject a configuration file in the pod
+    kubectl apply -f doc/test/templates/nextflow/nextflow_config.yaml -n cqgc-qa
+
+    # Create dedicated persistent volume, persistent volume claim and service account resources:
+    kubectl apply -f doc/test/templates/nextflow/nextflow.yaml -n cqgc-qa
+
+    # Make sure that the storage path associated to the persistent volume exists on the minikube container:    
+    docker exec -it minikube mkdir -p /mnt/cqgc-qa/nextflow
+    ```
+
+
+
+6. **Test**
+
+    You are now ready to execute a simple nextflow operator. Go to the airflow ui (localhost:50080), and run the dag `test_nextflow_operator.py`. 
+
+    You can use the following command to list the pods running in the minikube cluster:
+    `kubectl get pod -n cqgc-qa`

--- a/doc/test/readme.md
+++ b/doc/test/readme.md
@@ -1,0 +1,7 @@
+Contains description of procedures that you can use to test locally.
+
+## Files
+
+- **minikube_setup.md**: Deploy the full ETL, including airflow, in a minikube cluster.
+- **docker_compose_and_minikube_setup.md**: Deploy airflow with docker-compose and submit the tasks based on the KubernetesPodOperator on minikube.
+- **nextflow_setup.md**: Local minikube setup procedure common to most DAGs based on the nextflow operator.

--- a/doc/test/templates/README.md
+++ b/doc/test/templates/README.md
@@ -1,0 +1,1 @@
+This folder contains kubernetes template files used to test the ETL locally with minikube.

--- a/doc/test/templates/airflow/airflow.yaml
+++ b/doc/test/templates/airflow/airflow.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cqgc-qa-airflow-dags-pv
+  labels:
+    environment: airflow-qa
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  storageClassName: standard
+  hostPath:
+    path: /mnt/cqgc-qa/airflow/dags
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cqgc-qa-airflow-dags-pvc
+spec:
+  volumeName: cqgc-qa-airflow-dags-pv
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      environment: airflow-qa

--- a/doc/test/templates/airflow/values.yaml
+++ b/doc/test/templates/airflow/values.yaml
@@ -1,0 +1,34 @@
+env:
+  - name: "AIRFLOW_VAR_ENVIRONMENT"
+    value: "qa"
+  - name:  "AIRFLOW_VAR_KUBERNETES_NAMESPACE"
+    value: "cqgc-qa"
+  - name: "AIRFLOW_VAR_BASE_URL"
+    value: "http://localhost:50080"
+  - name: "AIRFLOW_VAR_SHOW_TEST_DAGS"
+    value:  "yes"
+
+
+images:
+  gitSync:
+    repository: ferlabcrsj/airflow_git-sync.git-sync
+    tag: v3.6.3
+    pullPolicy: IfNotPresent
+
+executor:  "KubernetesExecutor"
+
+dags:
+  persistence:
+    enabled: true
+    existingClaim: "cqgc-qa-airflow-dags-pvc" 
+
+  gitSync:
+    enabled: false
+
+logs:
+  persistence:
+    enabled: true
+
+config:
+  scheduler:
+    dag_dir_list_interval: 30

--- a/doc/test/templates/nextflow/minio_pv.yaml
+++ b/doc/test/templates/nextflow/minio_pv.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cqgc-qa-minio-pv
+  labels:
+    environment: minio-qa
+  
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  storageClassName: standard
+  hostPath:
+    path: /mnt/cqgc-qa/minio/data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cqgc-qa-minio-pvc
+spec:
+  volumeName: cqgc-qa-minio-pv
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      environment: minio-qa

--- a/doc/test/templates/nextflow/mock_minio.yaml
+++ b/doc/test/templates/nextflow/mock_minio.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: minio
+  name: minio
+  namespace: cqgc-qa # Change this value to match the namespace metadata.name
+spec:
+  containers:
+  - name: minio
+    image: minio/minio:RELEASE.2024-07-16T23-46-41Z.fips
+    #image: quay.io/minio/minio:latest
+    command:
+    - /bin/bash
+    - -c
+    args: 
+    - minio server /mnt/data --address :9090 --console-address :9091
+    volumeMounts:
+    - mountPath: /mnt/data
+      name: data-volume
+    env:
+        - name: MINIO_ROOT_USER
+          value: "minio"
+        - name: MINIO_ROOT_PASSWORD
+          value: "minio123"
+    
+  volumes:
+  - name: data-volume
+    persistentVolumeClaim:
+        claimName: cqgc-qa-minio-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: minio
+  name: minio
+spec:
+  ports:
+    - name: api
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+    - name: console
+      port: 9091
+      protocol: TCP
+      targetPort: 9091
+  selector:
+    app: minio

--- a/doc/test/templates/nextflow/nextflow.yaml
+++ b/doc/test/templates/nextflow/nextflow.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cqgc-qa-nextflow-pv
+  labels:
+    environment: nextflow-qa
+  
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  storageClassName: standard
+  hostPath:
+    path: /mnt/cqgc-qa/nextflow
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cqgc-qa-nextflow-pvc
+spec:
+  volumeName: cqgc-qa-nextflow-pv
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      environment: nextflow-qa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: nextflow
+  name: nextflow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: nextflow
+  name: nextflow
+rules:
+  - apiGroups: ['']
+    resources: ['pods', 'configmaps', 'pods/status', 'pods/logs']
+    verbs: ['get', 'list', 'watch', 'create', 'edit', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: nextflow
+  name: nextflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nextflow
+subjects:
+  - kind: ServiceAccount
+    name: nextflow

--- a/doc/test/templates/nextflow/nextflow_config.yaml
+++ b/doc/test/templates/nextflow/nextflow_config.yaml
@@ -1,0 +1,43 @@
+# Will be used to create a nextflow configuration file containing environment-specific details
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextflow
+  labels:
+    name: nextflow
+data:
+
+ # Note: the k8s settings here will need to be adjusted to match the environment.
+  nextflow.config: |
+
+    // Allow to cleanup the work directory if the pipeline is successful
+    cleanup = true
+
+    wave {
+        enabled = true
+    }
+
+    fusion {
+        enabled = true
+        exportStorageCredentials = true
+    }
+
+    process {
+        executor = 'k8s'
+
+        // Recommended when using fusion
+        scratch = false
+    }
+
+    k8s {
+        context = 'minikube'
+        namespace = 'cqgc-qa'
+        serviceAccount  = 'nextflow'
+    }
+
+    aws {
+      client {
+        endpoint = 'http://minio:9090'
+        s3PathStyleAccess = true
+      }
+    }


### PR DESCRIPTION
**Description**

To facilitate team collaboration, this PR introduces generic Nextflow code that can be reused and evolved by the team to implement Nextflow DAGs.

Additionally, we introduce a generic test nextflow DAG that allows launching ad hoc nextflow jobs from the Airflow UI. This feature enables users to test and validate their pipelines in a controlled environment before deploying them to production.

In the short term, we would like to use this DAG for testing an SNV clustering nextflow pipeline. To test with realistic data, it will probably need to run in the staging environment. Please keep this in mind during the review. 

Associated JIRA ticket:
https://ferlab-crsj.atlassian.net/browse/CLIN-3138

**Local tests**

I tested running the nextflow DAG locally with minikube. 

I included documentation about this test procedure in the code. Let me know if you want to keep it or if you prefer that I remove it from this PR.

**Running dag in ETL QA cluster**

I started airflow locally, with docker-compose, and set the `kubernetes_context_etl` variable to point on the etl cluster. I set the `kubernetes_namespace` variable to `cqgc-qa`.  Then I executed the test nextflow dag from the airflow UI.  It was executed successfully. I could see the different pods running on the cluster.

**Slack notifications**

I used the local setup with docker-compose and minikube to execute the nextflow dag. As instructed in the readme, I set the variable `slack_hook_url` to point on a test slack application that I created on a personal slack workspace.
 
The dag was executed successfully and I could see the notifications correctly sent to the test app before and after completing the nextflow job.

Here is a screenshot showing the slack notification sent:
<img width="685" alt="Capture d’écran, le 2024-09-05 à 20 27 56" src="https://github.com/user-attachments/assets/7a3338f1-9061-4b24-b789-f08776730386">

**Nextflow dag screenshot**

Here is what we see in the UI when we click the trigger button:
<img width="1514" alt="Capture d’écran, le 2024-09-05 à 20 39 35" src="https://github.com/user-attachments/assets/15a0349e-7fe1-4934-8ecc-1563f586bcc9">
