### PR TITLE
fix: CLIN-3230 use parameters configured in airflow UI in nextflow dag

### DIFF
--- a/dags/test_nextflow_operator.py
+++ b/dags/test_nextflow_operator.py
@@ -37,14 +37,15 @@ if (config.show_test_dags or env in [Env.QA, Env.STAGING]):
               but please use a location under this directory.
            """
            )
-       }
+       },
+       render_template_as_native_obj=True
     ) as dag:
         
         NextflowOperator(
             task_id='test_nextflow_operator',
             name="test_nextflow_operator", # prefix for the pod name
             k8s_context = K8sContext.ETL,
-            arguments =  dag.params["nextflow_command"],
+            arguments = "{{ params.nextflow_command }}",
             on_execute_callback=Slack.notify_dag_start,
             on_success_callback=Slack.notify_dag_completion,
         )

--- a/dags/test_nextflow_operator.py
+++ b/dags/test_nextflow_operator.py
@@ -22,30 +22,35 @@ if (config.show_test_dags or env in [Env.QA, Env.STAGING]):
         schedule=None,
         description="Run an ad-hoc nextflow command in a kubernetes pod.",
         params={
-        "nextflow_command": Param( 
-              DEFAULT_NEXTFLOW_COMMAND, 
-              type="array", 
-              description=f"""The nextflow command to be executed. 
-              This should be expressed as a list of arguments, which will be passed to the bash shell in the nextflow pod. 
-              Here each line represent a separate argument.  
+            "nextflow_command": Param(
+                DEFAULT_NEXTFLOW_COMMAND,
+                type="array",
+                description=f"""The nextflow command to be executed.
+                This should be expressed as a list of arguments, which will
+                be passed to the bash shell in the nextflow pod. Here each
+                line represent a separate argument.
 
-              Here the `/root/nextflow/config/nextflow.config` file is a valid nextflow configuration file that will be available in the pod. 
-              It contains configuration settings specific to the Qlin execution environment. 
-              You should always include it in your nextflow command, unless you have a valid reason not to.
+                Here the `/root/nextflow/config/nextflow.config` file is a
+                valid nextflow configuration file that will be available in
+                the pod. It contains configuration settings specific to the
+                Qlin execution environment. You should always include it in
+                your nextflow command, unless you have a valid reason not to.
 
-              The nextflow working directory is set to `{config.nextflow_working_dir}`. You can overwrite it via the `-work-dir` option, 
-              but please use a location under this directory.
-           """
-           )
-       },
-       render_template_as_native_obj=True
+                The nextflow working directory is set to
+                `{config.nextflow_working_dir}`. You can overwrite it via the
+                `-work-dir` option, but please use a location under this
+                directory.
+                """
+            )
+        },
+        render_template_as_native_obj=True
     ) as dag:
-        
+
         NextflowOperator(
             task_id='test_nextflow_operator',
-            name="test_nextflow_operator", # prefix for the pod name
-            k8s_context = K8sContext.ETL,
-            arguments = "{{ params.nextflow_command }}",
+            name="test_nextflow_operator",  # prefix for the pod name
+            k8s_context=K8sContext.ETL,
+            arguments="{{ params.nextflow_command }}",
             on_execute_callback=Slack.notify_dag_start,
             on_success_callback=Slack.notify_dag_completion,
         )

--- a/doc/test/minikube_setup.md
+++ b/doc/test/minikube_setup.md
@@ -53,7 +53,7 @@ Install airflow with helm:
 helm repo add apache-airflow https://airflow.apache.org
 
 # Then install airflow in the minikube cluster:
-helm upgrade --install airflow apache-airflow/airflow --version 1.11.0 --namespace cqgc-qa --values doc/test/templates/airflow/values.yaml
+helm upgrade --install airflow apache-airflow/airflow --version 1.15.0 --namespace cqgc-qa --values doc/test/templates/airflow/values.yaml
 ```
 
 Wait that all pods are ready and use the following command to access the airflow UI:


### PR DESCRIPTION
The default DAG parameters were used instead of the parameters configured in the UI. This commit addresses this issue.

Other changes:
- Bump the airflow helm chart version in the minikube setup procedure to match the version in QA.
- Fix style warnings reported by flake8

Associated JIRA:
https://ferlab-crsj.atlassian.net/browse/CLIN-3230

**Tests:**

I used a local setup with minikube to start airflow and installed components required by the nextflow dag.  See doc/test/nextflow_setup.md

**1) Execute nextflow dag with default parameters**
- The dag run was successful 
- I could see that the default nextflow hello command was executed on the pod through the task logs.

**2) Execute nextflow dag with manually provided command arguments**
In the airflow UI, I executed the nextflow dag with the following command: 
```
cat 
/root/nextflow/config/nextflow.config
```
- The dag run was successful
- I could see  in the task logs that the cat command was executed instead of the default nextflow hello command.

**3) Execute nextflow dag with manually provided command arguments of different types**
-In the airflow UI, I executed the nextflow dag with the following command:
```
echo
hello
1
1.3
"foo"
true
True
[4, 5, 6]
```
- The dag run was sucessful
- I could see in the task logs that the echo command was executed. We could see this line: `hello 1 1.3 "foo" true True [4, 5, 6]`
- I could see in task details that the pod command arguments attribute was set to:
`["echo","hello","1","3.0","\"foo\"","true","True","[4, 5, 6]"]`
Here, each argument passed is converted to a string, which is the desired behaviour.

