### PR TITLE
fix: CLIN-3267 typo in nextflow pipeline revision

### DIFF
--- a/dags/lib/operators/nextflow.py
+++ b/dags/lib/operators/nextflow.py
@@ -201,7 +201,7 @@ class NextflowOperatorConfig(BaseConfig):
 
     def with_revision(self, revision: str) -> Self:
         c = copy.copy(self)
-        c.pipeline_revision = revision
+        c.nextflow_pipeline_revision = revision
         return c
 
     def with_params_file(self, params_file: str) -> Self:


### PR DESCRIPTION
Fix broken etl.py dag (nextflow group) that is caused by a typo when specifying a nextflow operator attribute.

**Test procedure**

I run the problematic task (nextflow.svclustering_parental_origin) locally in a test dag, pointing on the qa etl cluster.
I could see that the test dag completed successfully and that nextflow jobs were run.
The dags take about 8 minutes to execute and consume, roughly, up to 10-15 pods in the cluster.

Below is a description of the procedure that I used. 

1. Create a minimalist test dag isolating the nextflow task posing problem:
```
from datetime import datetime
from typing import List

from airflow import DAG
from airflow.decorators import task
from airflow.models import DagRun
from airflow.models.param import Param
from lib.tasks import batch_type, nextflow

with DAG(
        dag_id='test_svclustering_task',
        start_date=datetime(2022, 1, 1),
        schedule_interval=None,
        params={
            'batch_ids': Param([], type=['null', 'array'], description='Put a single batch id per line.')
        },
        max_active_tasks=4,
        max_active_runs=1,
        render_template_as_native_obj=True,
        user_defined_macros={'any_in': batch_type.any_in}
) as dag:
    
    @task(task_id='get_ingest_dag_configs')
    def get_ingest_dag_config(batch_id: str, ti=None) -> dict:
        dag_run: DagRun = ti.dag_run
        return {
            'batch_id': batch_id
        }

    @task(task_id='get_batch_ids')
    def get_batch_ids(ti=None) -> List[str]:
        dag_run: DagRun = ti.dag_run
        ids = dag_run.conf['batch_ids'] if dag_run.conf['batch_ids'] is not None else []
        return list(set(ids))

    get_batch_ids_task = get_batch_ids()
    detect_batch_types_task = batch_type.detect.expand(batch_id=get_batch_ids_task)
    svclustering_parental_origin_task = nextflow.svclustering_parental_origin(batch_ids=get_batch_ids_task)

    get_batch_ids_task >>  detect_batch_types_task >> svclustering_parental_origin_task
```

2. In `dags/lib/tasks/nextflow.py`, change the output_key to point on `clin_scratch_bucket` instead `clin_datalake_bucket`

3. Start the application with docker-compose as instructed in the README and log in the UI.

4. Configure the minio connection
Go in the admin tab, select connection and create a new connection. Select Amazon Web Services as connection type. Fill in the information. In the "extra" section, you need to specify the endpoint url. The content of this section should look like this: 
```
{
  "endpoint_url": "QA_ENDPOINT_URL_HERE"
}
```
Note down the connection id that you chose.

5. Configure variables
Go in the admin tab, select variables. Change the `kubernetes_context_etl` variable so that it points on the etl cluster. Make sure that the `kubernetes_namespace` variable is set to `cqgc-qa` and that the environment variable is set to `qa`.
Create a new variable with name `s3_conn_id` and set the value to the connection id from step 4.

6. Run the test dag. Use the following batch types:
```
test_franklin
test_dragen_4_2_4_germline
```