### PR TITLE
feat: CLIN-3207 Normalize nextflow svcpo + Pass batch_id to enrich_cnv

### DIFF
--- a/dags/etl.py
+++ b/dags/etl.py
@@ -7,6 +7,7 @@ from airflow.models import DagRun
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
+
 from lib.config import Env, K8sContext, env
 from lib.groups.index.index import index
 from lib.groups.index.prepare_index import prepare_index
@@ -15,7 +16,7 @@ from lib.groups.qa import qa
 from lib.operators.notify import NotifyOperator
 from lib.operators.trigger_dagrun import TriggerDagRunOperator
 from lib.slack import Slack
-from lib.tasks import batch_type, enrich, nextflow
+from lib.tasks import batch_type, enrich
 from lib.tasks.batch_type import skip_if_no_batch_in
 from lib.tasks.params_validate import validate_release_color
 from lib.utils_etl import (ClinAnalysis, color, default_or_initial, release_id,
@@ -90,19 +91,6 @@ with DAG(
         wait_for_completion=True
     ).expand(conf=get_ingest_dag_configs_task)
 
-
-    @task_group(group_id="nextflow")
-    def nextflow_group():
-        prepare_svclustering_parental_origin_task = nextflow.prepare_svclustering_parental_origin(
-            batch_ids=get_batch_ids_task,
-            spark_jar=spark_jar()
-        )
-
-        svclustering_parental_origin_task = nextflow.svclustering_parental_origin(batch_ids=get_batch_ids_task)
-
-        prepare_svclustering_parental_origin_task >> svclustering_parental_origin_task
-
-
     steps = default_or_initial(batch_param_name='batch_ids')
 
 
@@ -115,47 +103,66 @@ with DAG(
             skip=skip_if_no_batch_in(target_batch_types=[ClinAnalysis.GERMLINE])
         )
 
-        # Only run snv_somatic if at least one somatic tumor only or somatic tumor normal batch
-        # Run snv_somatic_all if no batch ids are provided. Otherwise, run snv_somatic for each batch_id.
-        @task.branch(task_id='run_snv_somatic')
-        def run_snv_somatic(batch_ids: List[str]):
-            if not batch_ids:
-                return 'enrich.snv_somatic_all'
-            else:
-                return 'enrich.snv_somatic'
+        @task_group(group_id='snv_somatic')
+        def snv_somatic_group():
+            # Only run snv_somatic if at least one somatic tumor only or somatic tumor normal batch
+            # Run snv_somatic_all if no batch ids are provided. Otherwise, run snv_somatic for each batch_id.
+            @task.branch(task_id='run_snv_somatic')
+            def run_snv_somatic(batch_ids: List[str]):
+                if not batch_ids:
+                    return 'enrich.snv_somatic.snv_somatic_all'
+                else:
+                    return 'enrich.snv_somatic.snv_somatic'
 
-        run_snv_somatic_task = run_snv_somatic(batch_ids=get_batch_ids_task)
-        snv_somatic_target_types = [ClinAnalysis.SOMATIC_TUMOR_ONLY, ClinAnalysis.SOMATIC_TUMOR_NORMAL]
+            run_snv_somatic_task = run_snv_somatic(batch_ids=get_batch_ids_task)
+            snv_somatic_target_types = [ClinAnalysis.SOMATIC_TUMOR_ONLY, ClinAnalysis.SOMATIC_TUMOR_NORMAL]
 
-        snv_somatic_all = enrich.snv_somatic_all(
-            spark_jar=spark_jar(),
-            steps=steps,
-            skip=skip_if_no_batch_in(target_batch_types=snv_somatic_target_types)
-        )
+            snv_somatic_all = enrich.snv_somatic_all(
+                spark_jar=spark_jar(),
+                steps=steps,
+                skip=skip_if_no_batch_in(target_batch_types=snv_somatic_target_types)
+            )
 
-        snv_somatic = enrich.snv_somatic(
-            batch_ids=get_batch_ids_task,
-            spark_jar=spark_jar(),
-            steps=steps,
-            skip=skip_if_no_batch_in(snv_somatic_target_types),
-            target_batch_types=snv_somatic_target_types
-        )
+            snv_somatic = enrich.snv_somatic(
+                batch_ids=get_batch_ids_task,
+                spark_jar=spark_jar(),
+                steps=steps,
+                target_batch_types=snv_somatic_target_types
+            )
 
-        # Only run if at least one germline or somatic tumor only batch
-        cnv = enrich.cnv(
-            spark_jar=spark_jar(),
-            steps=steps,
-            skip=skip_if_no_batch_in(target_batch_types=[ClinAnalysis.GERMLINE,
-                                                         ClinAnalysis.SOMATIC_TUMOR_ONLY])
-        )
+            return run_snv_somatic_task >> [snv_somatic_all, snv_somatic]
+
+        @task_group(group_id='cnv')
+        def cnv_group():
+            # Only run cnv if at least one germline or somatic tumor only batch
+            # Run cnv_all if no batch ids are provided. Otherwise, run cnv for each batch_id.
+            @task.branch(task_id='run_cnv')
+            def run_cnv(batch_ids: List[str]):
+                if not batch_ids:
+                    return 'enrich.cnv.cnv_all'
+                else:
+                    return 'enrich.cnv.cnv'
+
+            run_cnv_task = run_cnv(batch_ids=get_batch_ids_task)
+            cnv_target_types = [ClinAnalysis.GERMLINE, ClinAnalysis.SOMATIC_TUMOR_ONLY]
+
+            cnv_all = enrich.cnv_all(spark_jar=spark_jar(), steps=steps, skip=skip_if_no_batch_in(cnv_target_types))
+            cnv = enrich.cnv(
+                batch_ids=get_batch_ids_task,
+                spark_jar=spark_jar(),
+                steps=steps,
+                skip=skip_if_no_batch_in(cnv_target_types),
+                target_batch_types=cnv_target_types
+            )
+
+            return run_cnv_task >> [cnv_all, cnv]
 
         # Always run variants, consequences and coverage by gene
         variants = enrich.variants(spark_jar=spark_jar(), steps=steps)
         consequences = enrich.consequences(spark_jar=spark_jar(), steps=steps)
         coverage_by_gene = enrich.coverage_by_gene(spark_jar=spark_jar(), steps=steps)
 
-        snv >> run_snv_somatic_task >> [snv_somatic_all,
-                                        snv_somatic] >> variants >> consequences >> cnv >> coverage_by_gene
+        snv >> snv_somatic_group() >> variants >> consequences >> cnv_group() >> coverage_by_gene
 
 
     prepare_group = prepare_index(
@@ -228,4 +235,4 @@ with DAG(
         on_success_callback=Slack.notify_dag_completion,
     )
 
-    params_validate_task >> get_batch_ids_task >> detect_batch_types_task >> get_ingest_dag_configs_task >> trigger_ingest_dags >> nextflow_group() >> enrich_group() >> prepare_group >> qa_group >> index_group >> publish_group >> notify_task >> trigger_rolling_dag >> slack >> trigger_qc_es_dag >> trigger_qc_dag
+    params_validate_task >> get_batch_ids_task >> detect_batch_types_task >> get_ingest_dag_configs_task >> trigger_ingest_dags >> enrich_group() >> prepare_group >> qa_group >> index_group >> publish_group >> notify_task >> trigger_rolling_dag >> slack >> trigger_qc_es_dag >> trigger_qc_dag

--- a/dags/etl_germline.py
+++ b/dags/etl_germline.py
@@ -53,6 +53,7 @@ with DAG(
         skip_exomiser=skip_batch(),
         skip_coverage_by_gene=skip_batch(),
         skip_franklin=skip_batch(),
+        skip_nextflow=skip_batch(),
         spark_jar=spark_jar(),
     )
 
@@ -62,7 +63,7 @@ with DAG(
         snv = enrich.snv(steps=default_or_initial(), spark_jar=spark_jar())
         variants = enrich.variants(spark_jar=spark_jar(), steps=default_or_initial())
         consequences = enrich.consequences(spark_jar=spark_jar(), steps=default_or_initial())
-        cnv = enrich.cnv(spark_jar=spark_jar(), steps=default_or_initial())
+        cnv = enrich.cnv_all(spark_jar=spark_jar(), steps=default_or_initial())
         coverage_by_gene = enrich.coverage_by_gene(spark_jar=spark_jar(), steps=default_or_initial())
 
         snv >> variants >> consequences >> cnv >> coverage_by_gene

--- a/dags/etl_ingest.py
+++ b/dags/etl_ingest.py
@@ -51,6 +51,7 @@ with DAG(
         skip_exomiser='',
         skip_coverage_by_gene='',
         skip_franklin='',
+        skip_nextflow='',
         spark_jar=spark_jar()
     )
 

--- a/dags/etl_migrate.py
+++ b/dags/etl_migrate.py
@@ -32,6 +32,7 @@ with DAG(
             'exomiser': Param('no', enum=['yes', 'no']),
             'coverage_by_gene': Param('no', enum=['yes', 'no']),
             'franklin': Param('no', enum=['yes', 'no']),
+            'nextflow': Param('no', enum=['yes', 'no']),
             'spark_jar': Param('', type=['null', 'string']),
         },
         default_args={
@@ -80,6 +81,10 @@ with DAG(
         return format_skip_condition('franklin')
 
 
+    def skip_nextflow() -> str:
+        return format_skip_condition('nextflow')
+
+
     params_validate_task = validate_color(
         color=color()
     )
@@ -109,6 +114,7 @@ with DAG(
                 skip_exomiser=skip_exomiser(),
                 skip_coverage_by_gene=skip_coverage_by_gene(),
                 skip_franklin=skip_franklin(),
+                skip_nextflow=skip_nextflow(),
                 spark_jar=spark_jar()
             )
 

--- a/dags/etl_reset_enrich_cnv.py
+++ b/dags/etl_reset_enrich_cnv.py
@@ -13,7 +13,7 @@ with DAG(
             'on_failure_callback': Slack.notify_task_failure,
         },
 ) as dag:
-    enrich.cnv(
+    enrich.cnv_all(
         steps='initial',
         task_id='reset_enrich_cnv',
         name='etl-reset-enrich-cnv',

--- a/dags/etl_somatic_tumor_only.py
+++ b/dags/etl_somatic_tumor_only.py
@@ -61,7 +61,7 @@ with DAG(
         snv_somatic_all = enrich.snv_somatic_all(spark_jar=spark_jar(), steps=default_or_initial())
         variants = enrich.variants(spark_jar=spark_jar(), steps=default_or_initial())
         consequences = enrich.consequences(spark_jar=spark_jar(), steps=default_or_initial())
-        cnv = enrich.cnv(spark_jar=spark_jar(), steps=default_or_initial())
+        cnv = enrich.cnv_all(spark_jar=spark_jar(), steps=default_or_initial())
         coverage_by_gene = enrich.coverage_by_gene(spark_jar=spark_jar(), steps=default_or_initial())
 
         snv_somatic_all >> variants >> consequences >> cnv >> coverage_by_gene

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -55,7 +55,7 @@ if env == Env.QA:
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 'clin-variant-etl-v3.4.10.jar'
+    spark_jar = 'clin-variant-etl-v3.5.0.jar'
     obo_parser_spark_jar = 'obo-parser-v1.1.0.jar'
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'

--- a/dags/lib/groups/ingest/ingest_germline.py
+++ b/dags/lib/groups/ingest/ingest_germline.py
@@ -20,6 +20,7 @@ def ingest_germline(
         skip_exomiser: str,
         skip_coverage_by_gene: str,
         skip_franklin: str,
+        skip_nextflow: str,
         spark_jar: str
 ):
     skip_all = batch_type.skip(ClinAnalysis.GERMLINE, batch_type_detected)
@@ -49,6 +50,7 @@ def ingest_germline(
         skip_exomiser=skip_exomiser,
         skip_coverage_by_gene=skip_coverage_by_gene,
         skip_franklin=skip_franklin,
+        skip_nextflow=skip_nextflow,
         spark_jar=spark_jar
     )
 

--- a/dags/lib/groups/migrate/migrate_germline.py
+++ b/dags/lib/groups/migrate/migrate_germline.py
@@ -15,6 +15,7 @@ def migrate_germline(
         skip_exomiser: str,
         skip_coverage_by_gene: str,
         skip_franklin: str,
+        skip_nextflow: str,
         spark_jar: str
 ):
     detect_batch_type_task_id = f"{get_group_id('migrate', batch_id)}.detect_batch_type"
@@ -40,6 +41,7 @@ def migrate_germline(
         skip_exomiser=skip_exomiser,
         skip_coverage_by_gene=skip_coverage_by_gene,
         skip_franklin=skip_franklin,
+        skip_nextflow=skip_nextflow,
         spark_jar=spark_jar,
     )
 

--- a/dags/lib/tasks/enrich.py
+++ b/dags/lib/tasks/enrich.py
@@ -91,8 +91,8 @@ def consequences(steps: str, spark_jar: str = '', task_id: str = 'consequences',
     )
 
 
-def cnv(steps: str, spark_jar: str = '', task_id: str = 'cnv', name: str = 'etl-enrich-cnv',
-        app_name: str = 'etl_enrich_cnv', skip: str = '', **kwargs) -> SparkETLOperator:
+def cnv_all(steps: str, spark_jar: str = '', task_id: str = 'cnv_all', name: str = 'etl-enrich-cnv-all',
+            app_name: str = 'etl_enrich_cnv_all', skip: str = '', **kwargs) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv',
         task_id=task_id,
@@ -105,6 +105,24 @@ def cnv(steps: str, spark_jar: str = '', task_id: str = 'cnv', name: str = 'etl-
         skip=skip,
         **kwargs
     )
+
+
+def cnv(batch_ids: List[str], steps: str, spark_jar: str = '', task_id: str = 'cnv', name: str = 'etl-enrich-cnv',
+        app_name: str = 'etl_enrich_cnv', skip: str = '', target_batch_types: List[ClinAnalysis] = None, **kwargs):
+    return SparkETLOperator.partial(
+        entrypoint='cnv',
+        task_id=task_id,
+        name=name,
+        steps=steps,
+        app_name=app_name,
+        spark_class=ENRICHED_MAIN_CLASS,
+        spark_config='config-etl-medium',
+        spark_jar=spark_jar,
+        skip=skip,
+        target_batch_types=target_batch_types,
+        max_active_tis_per_dag=1,  # Prevent multiple executions at the same time
+        **kwargs
+    ).expand(batch_id=batch_ids)
 
 
 def coverage_by_gene(steps: str, spark_jar: str = '', task_id: str = 'coverage_by_gene',


### PR DESCRIPTION
## Changes
* Move nextflow parental origin tasks to `etl_ingest`.
* Optionally pass `batch_id` to `enrich.cnv`. If no `batch_id` is passed to `etl` DAG, run `enrich.cnv` for all batches. Same behavior as `enrich.snv_somatic`.
* Put `enrich.cnv` and `enrich.snv_somatic` tasks into subgroups to simplify `etl` DAG graph.

## TO-DO

- [x] Update QA jar version when https://github.com/Ferlab-Ste-Justine/clin-variant-etl/pull/399 is merged.