### PR TITLE
feat: CLIN-3561 new etl to download gnomad genomes

### DIFF
--- a/dags/etl_import_gnomad_v4_genomes.py
+++ b/dags/etl_import_gnomad_v4_genomes.py
@@ -43,7 +43,6 @@ def etl_import_gnomad_v4_genomes():
             '--steps', 'default',
             '--app-name', 'etl_import_gnomad_v4_genomes',
         ],
-        on_success_callback=Slack.notify_dag_completion,
     )
 
     slack = EmptyOperator(task_id="slack", on_success_callback=Slack.notify_dag_completion)

--- a/dags/etl_import_gnomad_v4_genomes.py
+++ b/dags/etl_import_gnomad_v4_genomes.py
@@ -2,16 +2,13 @@ import logging
 from datetime import datetime
 from enum import Enum
 
-from airflow.decorators import dag, task
-from airflow.exceptions import AirflowSkipException
+from airflow.decorators import dag
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
-from lib import config
-from lib.config import clin_datalake_bucket, K8sContext, config_file
+from lib.config import K8sContext, config_file
 from lib.slack import Slack
 from lib.operators.spark import SparkOperator
-from lib.utils_import import stream_upload_to_s3, get_s3_file_version
 
 
 class SequencingType(Enum):
@@ -33,43 +30,6 @@ GNOMAD_S3_BUCKET = "gnomad-public-us-east-1"
     },
 )
 def etl_import_gnomad_v4_genomes():
-    clin_s3 = S3Hook(config.s3_conn_id)
-    gnomad_s3 = S3Hook(config.s3_gnomad)
-
-    @task(task_id="download_genomes_files")
-    def download_files(sequencing_type: SequencingType):
-        seq_type = sequencing_type.value
-        destination_prefix = f'raw/landing/gnomad_v{LATEST_VERSION.replace(".", "_")}/{seq_type}'
-        gnomad_prefix = f"release/{LATEST_VERSION}/vcf/{seq_type}"
-
-        # Get imported version
-        imported_ver = get_s3_file_version(clin_s3, clin_datalake_bucket, destination_prefix)
-        logging.info(f"Current gnomAD {seq_type} imported version: {imported_ver}")
-
-        # Skip task if up to date
-        if imported_ver == LATEST_VERSION:
-            logging.warning(f"Skipping import of gnomAD {seq_type}. Imported version {imported_ver} is up to date.")
-            raise AirflowSkipException()
-
-        # Download files
-        logging.info(f"Importing gnomAD {seq_type} version: {LATEST_VERSION}")
-        keys = keys = gnomad_s3.list_keys(bucket_name=GNOMAD_S3_BUCKET, prefix=f"{gnomad_prefix}/")
-
-        for key in keys:
-            if not key.endswith("/"):
-                generation_params = {"Bucket": GNOMAD_S3_BUCKET, "Key": key}
-                presigned_url = gnomad_s3.generate_presigned_url("get_object", params=generation_params)
-                destination_key = f"{destination_prefix}/{key}"
-
-                logging.info(f"Importing file {key}")
-
-                stream_upload_to_s3(clin_s3, clin_datalake_bucket, destination_key, presigned_url)
-
-        # Update version
-        logging.info(f"Version {LATEST_VERSION} of gnomAD {seq_type} imported to S3.")
-        clin_s3.load_string(LATEST_VERSION, f"{destination_prefix}.version", clin_datalake_bucket, replace=True)
-
-    genome_files = download_files(SequencingType.GENOMES)
 
     table = SparkOperator(
         task_id='table',
@@ -86,7 +46,9 @@ def etl_import_gnomad_v4_genomes():
         on_success_callback=Slack.notify_dag_completion,
     )
 
-    [genome_files] >> table
+    slack = EmptyOperator(task_id="slack", on_success_callback=Slack.notify_dag_completion)
+
+    table >> slack
 
 
 etl_import_gnomad_v4_genomes()

--- a/dags/etl_import_gnomad_v4_genomes.py
+++ b/dags/etl_import_gnomad_v4_genomes.py
@@ -1,0 +1,78 @@
+import logging
+from datetime import datetime
+from enum import Enum
+
+from airflow.decorators import dag, task
+from airflow.exceptions import AirflowSkipException
+from airflow.operators.empty import EmptyOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+from lib import config
+from lib.config import clin_datalake_bucket
+from lib.slack import Slack
+from lib.utils_import import stream_upload_to_s3, get_s3_file_version
+
+
+class SequencingType(Enum):
+    GENOMES = "genomes"
+    EXOMES = "exomes"
+
+
+LATEST_VERSION = "4.1"
+GNOMAD_S3_BUCKET = "gnomad-public-us-east-1"
+
+
+@dag(
+    dag_id="etl_import_gnomad_v4_genomes",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval=None,
+    max_active_tasks=1,
+    default_args={
+        "on_failure_callback": Slack.notify_task_failure,
+    },
+)
+def etl_import_gnomad_v4_genomes():
+    clin_s3 = S3Hook(config.s3_conn_id)
+    gnomad_s3 = S3Hook(config.s3_gnomad)
+
+    @task(task_id="download_genomes_files")
+    def download_files(sequencing_type: SequencingType):
+        seq_type = sequencing_type.value
+        destination_prefix = f'raw/landing/gnomad_v{LATEST_VERSION.replace(".", "_")}/{seq_type}'
+        gnomad_prefix = f"release/{LATEST_VERSION}/vcf/{seq_type}"
+
+        # Get imported version
+        imported_ver = get_s3_file_version(clin_s3, clin_datalake_bucket, destination_prefix)
+        logging.info(f"Current gnomAD {seq_type} imported version: {imported_ver}")
+
+        # Skip task if up to date
+        if imported_ver == LATEST_VERSION:
+            logging.warning(f"Skipping import of gnomAD {seq_type}. Imported version {imported_ver} is up to date.")
+            raise AirflowSkipException()
+
+        # Download files
+        logging.info(f"Importing gnomAD {seq_type} version: {LATEST_VERSION}")
+        keys = keys = gnomad_s3.list_keys(bucket_name=GNOMAD_S3_BUCKET, prefix=f"{gnomad_prefix}/")
+
+        for key in keys:
+            if not key.endswith("/"):
+                generation_params = {"Bucket": GNOMAD_S3_BUCKET, "Key": key}
+                presigned_url = gnomad_s3.generate_presigned_url("get_object", params=generation_params)
+                destination_key = f"{destination_prefix}/{key}"
+
+                logging.info(f"Importing file {key}")
+
+                stream_upload_to_s3(clin_s3, clin_datalake_bucket, destination_key, presigned_url)
+
+        # Update version
+        logging.info(f"Version {LATEST_VERSION} of gnomAD {seq_type} imported to S3.")
+        clin_s3.load_string(LATEST_VERSION, f"{destination_prefix}.version", clin_datalake_bucket, replace=True)
+
+    genome_files = download_files(SequencingType.GENOMES)
+
+    slack = EmptyOperator(task_id="slack", on_success_callback=Slack.notify_dag_completion)
+
+    [genome_files] >> slack
+
+
+etl_import_gnomad_v4_genomes()

--- a/dags/etl_import_gnomad_v4_genomes.py
+++ b/dags/etl_import_gnomad_v4_genomes.py
@@ -32,16 +32,19 @@ GNOMAD_S3_BUCKET = "gnomad-public-us-east-1"
 def etl_import_gnomad_v4_genomes():
 
     table = SparkOperator(
-        task_id='table',
-        name='etl_import_gnomad_v4_genomes',
+        task_id="table",
+        name="etl_import_gnomad_v4_genomes",
         k8s_context=K8sContext.ETL,
-        spark_class='bio.ferlab.datalake.spark3.publictables.ImportPublicTable',
-        spark_config='config-etl-large',
+        spark_class="bio.ferlab.datalake.spark3.publictables.ImportPublicTable",
+        spark_config="config-etl-large",
         arguments=[
-            'gnomadv4',
-            '--config', config_file,
-            '--steps', 'default',
-            '--app-name', 'etl_import_gnomad_v4_genomes',
+            "gnomadv4",
+            "--config",
+            config_file,
+            "--steps",
+            "default",
+            "--app-name",
+            "etl_import_gnomad_v4_genomes",
         ],
     )
 

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -25,7 +25,6 @@ k8s_context = {
 base_url = Variable.get('base_url', None)
 s3_conn_id = Variable.get('s3_conn_id', None)
 s3_franklin = Variable.get('s3_franklin', None)
-s3_gnomad = Variable.get('s3_gnomad', None)
 s3_franklin_bucket = Variable.get('s3_franklin_bucket', None)
 franklin_url = Variable.get('franklin_url', None)
 franklin_email = Variable.get('franklin_email', None)

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -25,6 +25,7 @@ k8s_context = {
 base_url = Variable.get('base_url', None)
 s3_conn_id = Variable.get('s3_conn_id', None)
 s3_franklin = Variable.get('s3_franklin', None)
+s3_gnomad = Variable.get('s3_gnomad', None)
 s3_franklin_bucket = Variable.get('s3_franklin_bucket', None)
 franklin_url = Variable.get('franklin_url', None)
 franklin_email = Variable.get('franklin_email', None)

--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -54,7 +54,7 @@ if env == Env.QA:
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 'clin-variant-etl-v3.6.2.jar'
+    spark_jar = 'clin-variant-etl-v3.7.0.jar'
     obo_parser_spark_jar = 'obo-parser-v1.1.0.jar'
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'


### PR DESCRIPTION
Question:
- I used `destination_prefix = f'raw/landing/gnomad_v{LATEST_VERSION.replace(".", "_")}/{seq_type}'` where destination will have a "4_1" in the path, would it be preferable to have only "4" instead?

Note:
- I had to use the extra connection config for the gnomad connection to work
```
{
  "config_kwargs": {
    "signature_version": "unsigned"
  }
}
```