### PR TITLE
feat: CLIN-3678 Update ferlabsvclustering nextflow pipeline to 1.2.0

### DIFF
--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -23,7 +23,7 @@ default_nextflow_config_file = f"{default_nextflow_config_map.mount_path}/nextfl
 ##################################
 # Define nextflow revisions here #
 ##################################
-nextflow_svclustering_revision = 'v1.1.1-clin'
+nextflow_svclustering_revision = 'v1.2.0-clin'
 nextflow_svclustering_parental_origin_revision = 'v1.1.1-clin'
 
 #######################################


### PR DESCRIPTION
By default, the new version 1.2.0 will only include variants with the filter column set to PASS.

If needed, this behaviour can be turned off by setting parameter include_only_pass_variants to false.