### PR TITLE
feat: CLIN-3267 add variant annotation nextflow task

### DIFF
--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -20,14 +20,25 @@ default_nextflow_config_map = ConfigMap(
 )
 default_nextflow_config_file = f"{default_nextflow_config_map.mount_path}/nextflow.config"
 
+nextflow_variant_annotation_config_map = ConfigMap(
+    name='nextflow-postprocessing',
+    mount_path='/root/nextflow/config/postprocessing'
+)
+nextflow_variant_annotation_config_file = f"{nextflow_variant_annotation_config_map.mount_path}/postprocessing.config"
+nextflow_variant_annotation_params_file = f"{nextflow_variant_annotation_config_map.mount_path}/postprocessing-params.json"
+
 ##################################
 # Define nextflow revisions here #
 ##################################
 nextflow_svclustering_revision = 'v1.2.0-clin'
 nextflow_svclustering_parental_origin_revision = 'v1.1.1-clin'
 
+nextflow_variant_annotation_revision = 'v2.4.1'
+
 #######################################
 # Define nextflow pipeline names here #
 #######################################
 nextflow_svclustering_pipeline = 'Ferlab-Ste-Justine/ferlab-svclustering'
 nextflow_svclustering_parental_origin_pipeline = 'Ferlab-Ste-Justine/ferlab-svclustering-parental-origin'
+
+nextflow_variant_annotation_pipeline = 'Ferlab-Ste-Justine/Post-processing-Pipeline'

--- a/dags/lib/tasks/nextflow.py
+++ b/dags/lib/tasks/nextflow.py
@@ -1,7 +1,19 @@
 from lib.config import clin_datalake_bucket
-from lib.config_nextflow import nextflow_svclustering_revision, nextflow_svclustering_parental_origin_pipeline, \
-    nextflow_svclustering_parental_origin_revision, nextflow_svclustering_pipeline
-from lib.config_operators import nextflow_svclustering_base_config
+from lib.config_nextflow import (
+    nextflow_svclustering_revision,
+    nextflow_svclustering_parental_origin_pipeline,
+    nextflow_svclustering_parental_origin_revision,
+    nextflow_svclustering_pipeline,
+    nextflow_variant_annotation_revision,
+    nextflow_variant_annotation_pipeline,
+    nextflow_variant_annotation_config_map,
+    nextflow_variant_annotation_config_file,
+    nextflow_variant_annotation_params_file
+)
+from lib.config_operators import (
+    nextflow_base_config,
+    nextflow_svclustering_base_config
+)
 from lib.operators.nextflow import NextflowOperator
 from lib.operators.spark_etl import SparkETLOperator
 
@@ -106,3 +118,28 @@ def normalize_svclustering_parental_origin(batch_id: str, spark_jar: str, skip: 
         batch_id=batch_id,
         **kwargs
     )
+
+
+######################
+# VARIANT ANNOTATION #
+######################
+
+
+def variant_annotation(input: str, outdir: str, skip: str = '', **kwargs):
+    nextflow_base_config \
+        .with_pipeline(nextflow_variant_annotation_pipeline) \
+        .with_revision(nextflow_variant_annotation_revision) \
+        .append_config_maps(nextflow_variant_annotation_config_map) \
+        .append_config_files(nextflow_variant_annotation_config_file) \
+        .with_params_file(nextflow_variant_annotation_params_file) \
+        .append_args(
+            '--input', input,
+            '--outdir', outdir
+        ) \
+        .operator(
+            NextflowOperator,
+            task_id='variant_annotation',
+            name='variant_annotation',
+            skip=skip,
+            **kwargs
+        )

--- a/dags/test_nextflow_variant_annotation.py
+++ b/dags/test_nextflow_variant_annotation.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+
+
+from lib import config
+from lib.config import env, Env
+from lib.slack import Slack
+
+from lib.tasks.nextflow import variant_annotation
+
+DEFAULT_INPUT_FILE = f"s3://cqgc-{env}-app-files-import/test_ferlab_variant_annotation_pipeline/datasets/dragen_4_2_4_small/samplesheet.csv"
+DEFAULT_OUTPUT_DIR = f"s3://cqgc-{env}-app-files-scratch/test_ferlab_variant_annotation_pipeline/dragen_4_2_4_small/output"
+
+if config.show_test_dags and env == Env.QA:
+    with DAG(
+            dag_id="test_nextflow_variant_annotation_task",
+            start_date=datetime(2022, 1, 1),
+            schedule=None,
+            description="DAG for testing the nextflow variant annotation task",
+            params={
+                'input': Param(
+                    DEFAULT_INPUT_FILE,
+                    type='string',
+                    description='The input samplesheet file to process.'
+                ),
+                'outdir': Param(
+                    DEFAULT_OUTPUT_DIR,
+                    type='string',
+                    description='The output directory to store the results.'
+                ),
+            },
+            render_template_as_native_obj=True
+    ) as dag:
+        variant_annotation(
+            input="{{ params.input }}",
+            outdir="{{ params.outdir }}",
+            on_execute_callback=Slack.notify_dag_start,
+            on_success_callback=Slack.notify_dag_completion
+        )


### PR DESCRIPTION
This pull request introduces a task to launch the Nextflow variant annotation pipeline, i.e. this pipeline:
https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline

It also includes a test DAG to validate the task until the preliminary ETL tasks are implemented.
For now, the DAG will appear only in QA.

**Tests**

Started Airflow locally with Docker Compose and launched the test DAG on the QA Kubernetes ETL cluster. The DAG was executed successfully.

I did a rebase and minor cosmetic changes after this test, so it would be a good idea to re-test.  Will wait to see if there are corrections requested before doing so.
