### PR TITLE
fix: CLIN-3879 Enforce etl cnv frequencies schedule at 2 AM

### DIFF
--- a/dags/etl_cnv_frequencies.py
+++ b/dags/etl_cnv_frequencies.py
@@ -15,7 +15,7 @@ with DAG(
         dag_id='etl_cnv_frequencies',
         doc_md=doc.cnv_frequencies,
         start_date=datetime(2024, 10, 20, 2, tzinfo=pendulum.timezone("America/Montreal")),
-        schedule=timedelta(days=1) if env == Env.PROD else None,
+        schedule="0 2 * * *" if env == Env.PROD else None,
         params={
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),


### PR DESCRIPTION
## 🩹  Fix details
Updating the `start_date` time alone was not enough to ensure the DAG runs at 2 AM. To enforce this schedule, we need to use a CRON expression in the `schedule` parameter.

## 🔗 Related Jira issue
[CLIN-3879](https://ferlab-crsj.atlassian.net/browse/CLIN-3879)


[CLIN-3879]: https://ferlab-crsj.atlassian.net/browse/CLIN-3879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ