### PR TITLE
feat: CLIN-3982 cnv frequencies + delete release

### DIFF
--- a/dags/etl.py
+++ b/dags/etl.py
@@ -252,6 +252,7 @@ with DAG(
         wait_for_completion=True,
         skip=skip_delete_previous_releases(),
         conf={
+            'release_id': release_id(),
             'color': color(),
         }
     )

--- a/dags/etl.py
+++ b/dags/etl.py
@@ -7,8 +7,8 @@ from airflow.models import DagRun
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
-
 from lib.config import Env, K8sContext, env
+from lib.groups.index.delete_previous_releases import delete_previous_releases
 from lib.groups.index.get_release_ids import get_release_ids
 from lib.groups.index.index import index
 from lib.groups.index.prepare_index import prepare_index
@@ -33,6 +33,8 @@ with DAG(
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),
             'import': Param('yes', enum=['yes', 'no']),
+            'cnv_frequencies': Param('yes', enum=['yes', 'no']),
+            'delete_previous_releases': Param('yes', enum=['yes', 'no']),
             'notify': Param('no', enum=['yes', 'no']),
             'qc': Param('yes', enum=['yes', 'no']),
             'rolling': Param('no', enum=['yes', 'no']),
@@ -50,6 +52,11 @@ with DAG(
     def skip_qc() -> str:
         return '{% if params.qc == "yes" %}{% else %}yes{% endif %}'
 
+    def skip_cnv_frequencies() -> str:
+        return '{% if params.cnv_frequencies == "yes" %}{% else %}yes{% endif %}'
+    
+    def skip_delete_previous_releases() -> str:
+        return '{% if params.delete_previous_releases == "yes" %}{% else %}yes{% endif %}'
 
     def skip_rolling() -> str:
         if env != Env.QA:
@@ -239,6 +246,28 @@ with DAG(
         }
     )
 
+    delete_previous_releases = delete_previous_releases(
+        gene_centric_release_id=release_id('gene_centric'),
+        gene_suggestions_release_id=release_id('gene_suggestions'),
+        variant_centric_release_id=release_id('variant_centric'),
+        variant_suggestions_release_id=release_id('variant_suggestions'),
+        coverage_by_gene_centric_release_id=release_id('coverage_by_gene_centric'),
+        cnv_centric_release_id=release_id('cnv_centric'),
+        color=color('_'),
+        skip=skip_delete_previous_releases()
+    )
+
+    trigger_cnv_frequencies = TriggerDagRunOperator(
+        task_id='cnv_frequencies',
+        trigger_dag_id='etl_cnv_frequencies',
+        wait_for_completion=False,
+        skip=skip_cnv_frequencies(),
+        conf={
+            'color': color(),
+            'spark_jar': spark_jar()
+        }
+    )
+
     slack = EmptyOperator(
         task_id="slack",
         on_success_callback=Slack.notify_dag_completion,
@@ -246,4 +275,4 @@ with DAG(
 
     (params_validate_task >> get_batch_ids_task >> detect_batch_types_task >> get_ingest_dag_configs_task >>
      trigger_ingest_dags >> enrich_group() >> prepare_group >> qa_group >> get_release_ids_group >> index_group >>
-     publish_group >> notify_task >> trigger_rolling_dag >> slack >> trigger_qc_es_dag >> trigger_qc_dag)
+     publish_group >> notify_task >> trigger_rolling_dag >> slack >> delete_previous_releases >> trigger_qc_es_dag >> trigger_cnv_frequencies >> trigger_qc_dag)

--- a/dags/etl.py
+++ b/dags/etl.py
@@ -246,21 +246,20 @@ with DAG(
         }
     )
 
-    delete_previous_releases = delete_previous_releases(
-        gene_centric_release_id=release_id('gene_centric'),
-        gene_suggestions_release_id=release_id('gene_suggestions'),
-        variant_centric_release_id=release_id('variant_centric'),
-        variant_suggestions_release_id=release_id('variant_suggestions'),
-        coverage_by_gene_centric_release_id=release_id('coverage_by_gene_centric'),
-        cnv_centric_release_id=release_id('cnv_centric'),
-        color=color('_'),
-        skip=skip_delete_previous_releases()
+    trigger_delete_previous_releases = TriggerDagRunOperator(
+        task_id='delete_previous_releases',
+        trigger_dag_id='etl_delete_previous_releases',
+        wait_for_completion=True,
+        skip=skip_delete_previous_releases(),
+        conf={
+            'color': color(),
+        }
     )
 
     trigger_cnv_frequencies = TriggerDagRunOperator(
         task_id='cnv_frequencies',
         trigger_dag_id='etl_cnv_frequencies',
-        wait_for_completion=False,
+        wait_for_completion=True,
         skip=skip_cnv_frequencies(),
         conf={
             'color': color(),
@@ -275,4 +274,4 @@ with DAG(
 
     (params_validate_task >> get_batch_ids_task >> detect_batch_types_task >> get_ingest_dag_configs_task >>
      trigger_ingest_dags >> enrich_group() >> prepare_group >> qa_group >> get_release_ids_group >> index_group >>
-     publish_group >> notify_task >> trigger_rolling_dag >> slack >> delete_previous_releases >> trigger_qc_es_dag >> trigger_cnv_frequencies >> trigger_qc_dag)
+     publish_group >> notify_task >> trigger_rolling_dag >> slack >> trigger_delete_previous_releases >> trigger_qc_es_dag >> trigger_cnv_frequencies >> trigger_qc_dag)

--- a/dags/etl_cnv_frequencies.py
+++ b/dags/etl_cnv_frequencies.py
@@ -15,7 +15,7 @@ with DAG(
         dag_id='etl_cnv_frequencies',
         doc_md=doc.cnv_frequencies,
         start_date=datetime(2024, 10, 20, 2, tzinfo=pendulum.timezone("America/Montreal")),
-        schedule="0 2 * * *" if env == Env.PROD else None,
+        schedule_interval=None,
         params={
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),
@@ -48,7 +48,7 @@ with DAG(
     publish_cnv_centric_task = publish_index.cnv_centric(release_id, color('_'), spark_jar(),
                                                          task_id='publish_cnv_centric',
                                                          on_success_callback=Slack.notify_dag_completion)
-    delete_previous_release_task = es.delete_previous_release('cnv_centric', release_id, color('_'))
+    delete_previous_release_task = es.delete_previous_cnv_centric_release(release_id, color('_'))
 
     (params_validate_task >> prepare_svclustering_task >> run_svclustering_task >> normalize_svclustering_task >>
      enrich_cnv_task >> prepare_cnv_centric_task >> qa_group() >> index_cnv_centric_task >> publish_cnv_centric_task >> delete_previous_release_task)

--- a/dags/etl_cnv_frequencies.py
+++ b/dags/etl_cnv_frequencies.py
@@ -48,7 +48,7 @@ with DAG(
     publish_cnv_centric_task = publish_index.cnv_centric(release_id, color('_'), spark_jar(),
                                                          task_id='publish_cnv_centric',
                                                          on_success_callback=Slack.notify_dag_completion)
-    delete_previous_release_task = es.delete_previous_cnv_centric_release(release_id, color('_'))
+    delete_previous_release_task = es.delete_previous_release('cnv_centric', release_id, color('_'))
 
     (params_validate_task >> prepare_svclustering_task >> run_svclustering_task >> normalize_svclustering_task >>
      enrich_cnv_task >> prepare_cnv_centric_task >> qa_group() >> index_cnv_centric_task >> publish_cnv_centric_task >> delete_previous_release_task)

--- a/dags/etl_delete_previous_releases.py
+++ b/dags/etl_delete_previous_releases.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.exceptions import AirflowFailException
+from airflow.models.param import Param
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import task
+from airflow.utils.trigger_rule import TriggerRule
+from lib.config import K8sContext, env, es_url
+from lib.groups.index.delete_previous_releases import delete_previous_releases
+from lib.operators.curl import CurlOperator
+from lib.slack import Slack
+from lib.tasks import es
+from lib.tasks.params_validate import validate_color
+from lib.utils_es import format_es_url
+from lib.utils_etl import color, release_id, skip_if_param_not
+
+with DAG(
+        dag_id='etl_delete_previous_releases',
+        start_date=datetime(2022, 1, 1),
+        schedule_interval=None,
+        params={
+            'color': Param('', type=['null', 'string']),
+        },
+         default_args={
+            'trigger_rule': TriggerRule.NONE_FAILED,
+            'on_failure_callback': Slack.notify_task_failure,
+        },
+        max_active_tasks=1,
+        max_active_runs=1,
+) as dag:
+
+    params_validate = validate_color(color())
+
+    delete_previous_releases = delete_previous_releases(
+        gene_centric_release_id=release_id('gene_centric'),
+        gene_suggestions_release_id=release_id('gene_suggestions'),
+        variant_centric_release_id=release_id('variant_centric'),
+        variant_suggestions_release_id=release_id('variant_suggestions'),
+        coverage_by_gene_centric_release_id=release_id('coverage_by_gene_centric'),
+        cnv_centric_release_id=release_id('cnv_centric'),
+        color=color('_'),
+        skip=''
+    )
+
+    slack = EmptyOperator(
+        task_id="slack",
+        on_success_callback=Slack.notify_dag_completion
+    )
+
+    params_validate >> delete_previous_releases >> slack

--- a/dags/etl_qc_es.py
+++ b/dags/etl_qc_es.py
@@ -9,7 +9,7 @@ from lib.slack import Slack
 with DAG(
     dag_id='etl_qc_es',
     start_date=datetime(2022, 1, 1),
-    schedule_interval='0 1 * * *',
+    schedule_interval=None,
     catchup=False,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,

--- a/dags/lib/groups/index/delete_previous_releases.py
+++ b/dags/lib/groups/index/delete_previous_releases.py
@@ -15,11 +15,22 @@ def delete_previous_releases(
         color: str,
         skip: str = ''
 ):
-    delete_gene_centric = es.delete_previous_gene_centric_release(gene_centric_release_id, color, skip=skip)
-    delete_gene_suggestions = es.delete_previous_gene_suggestions_release(gene_suggestions_release_id, color)
-    delete_variant_centric = es.delete_previous_variant_centric_release(variant_centric_release_id, color, skip=skip)
-    delete_variant_suggestions = es.delete_previous_variant_suggestions_release(variant_suggestions_release_id, color, skip=skip)
-    delete_cnv_centric = es.delete_previous_cnv_centric_release(cnv_centric_release_id, color, skip=skip)
-    delete_coverage_by_gene_centric = es.delete_previous_coverage_by_gene_centric_release(coverage_by_gene_centric_release_id, color, skip=skip)
+    delete_gene_centric = es.delete_previous_release \
+        .override(task_id='delete_gene_centric')(index_name='gene_centric', release_id=gene_centric_release_id, color=color, skip=skip)
+
+    delete_gene_suggestions = es.delete_previous_release \
+        .override(task_id='delete_gene_suggestions')(index_name='gene_suggestions', release_id=gene_suggestions_release_id, color=color, skip=skip)
+
+    delete_variant_centric = es.delete_previous_release \
+        .override(task_id='delete_variant_centric')(index_name='variant_centric', release_id=variant_centric_release_id, color=color, skip=skip)
+
+    delete_variant_suggestions = es.delete_previous_release \
+        .override(task_id='delete_variant_suggestions')(index_name='variant_suggestions', release_id=variant_suggestions_release_id, color=color, skip=skip)
+
+    delete_cnv_centric = es.delete_previous_release \
+        .override(task_id='delete_cnv_centric')(index_name='cnv_centric', release_id=cnv_centric_release_id, color=color, skip=skip)
+
+    delete_coverage_by_gene_centric = es.delete_previous_release \
+        .override(task_id='delete_coverage_by_gene_centric')(index_name='coverage_by_gene_centric', release_id=coverage_by_gene_centric_release_id, color=color, skip=skip)
 
     [delete_gene_centric, delete_gene_suggestions, delete_variant_centric, delete_variant_suggestions, delete_cnv_centric, delete_coverage_by_gene_centric]

--- a/dags/lib/groups/index/delete_previous_releases.py
+++ b/dags/lib/groups/index/delete_previous_releases.py
@@ -1,0 +1,25 @@
+from airflow.decorators import task_group
+from lib.slack import Slack
+from lib.tasks import arranger, es
+from lib.tasks import publish_index as publish
+
+
+@task_group(group_id='delete_previous_releases')
+def delete_previous_releases(
+        gene_centric_release_id: str,
+        gene_suggestions_release_id: str,
+        variant_centric_release_id: str,
+        variant_suggestions_release_id: str,
+        cnv_centric_release_id: str,
+        coverage_by_gene_centric_release_id: str,
+        color: str,
+        skip: str = ''
+):
+    delete_gene_centric = es.delete_previous_gene_centric_release(gene_centric_release_id, color, skip=skip)
+    delete_gene_suggestions = es.delete_previous_gene_suggestions_release(gene_suggestions_release_id, color)
+    delete_variant_centric = es.delete_previous_variant_centric_release(variant_centric_release_id, color, skip=skip)
+    delete_variant_suggestions = es.delete_previous_variant_suggestions_release(variant_suggestions_release_id, color, skip=skip)
+    delete_cnv_centric = es.delete_previous_cnv_centric_release(cnv_centric_release_id, color, skip=skip)
+    delete_coverage_by_gene_centric = es.delete_previous_coverage_by_gene_centric_release(coverage_by_gene_centric_release_id, color, skip=skip)
+
+    [delete_gene_centric, delete_gene_suggestions, delete_variant_centric, delete_variant_suggestions, delete_cnv_centric, delete_coverage_by_gene_centric]

--- a/dags/lib/tasks/es.py
+++ b/dags/lib/tasks/es.py
@@ -17,12 +17,14 @@ def get_previous_release(release: str, n: int = 2):
     previous_release = f"re_{previous_num:03d}"
     return previous_release
 
-@task(task_id='delete_previous_release')
+
 def delete_previous_release(index_name: str, release_id: str, under_color: str, skip=None):
     if skip:
         raise AirflowSkipException()
 
     previous_release = get_previous_release(release_id)
+
+    logging.info(f'Delete previous release for index: {index_name} {previous_release}')
 
     response = requests.delete(f'{es_url}/clin_{env}{under_color}_{index_name}_{previous_release}?ignore_unavailable=true', verify=False)
     logging.info(f'ES response:\n{response.text}')
@@ -32,6 +34,30 @@ def delete_previous_release(index_name: str, release_id: str, under_color: str, 
 
     return
 
+@task(task_id='delete_previous_gene_centric_release')
+def delete_previous_gene_centric_release(release_id: str, color: str, skip=None):
+    delete_previous_release('gene_centric', release_id, color, skip=skip)
+
+@task(task_id='delete_previous_gene_suggestions_release')
+def delete_previous_gene_suggestions_release(release_id: str, color: str, skip=None):
+    delete_previous_release('gene_suggestions', release_id, color, skip=skip)
+
+@task(task_id='delete_previous_variant_centric_release')
+def delete_previous_variant_centric_release(release_id: str, color: str, skip=None):
+    delete_previous_release('variant_centric', release_id, color, skip=skip)
+
+@task(task_id='delete_previous_variant_suggestions_release')
+def delete_previous_variant_suggestions_release(release_id: str, color: str, skip=None):
+    delete_previous_release('variant_suggestions', release_id, color, skip=skip)
+
+@task(task_id='delete_previous_cnv_centric_release')
+def delete_previous_cnv_centric_release(release_id: str, color: str, skip=None):
+    delete_previous_release('cnv_centric', release_id, color, skip=skip)
+
+@task(task_id='delete_previous_coverage_by_gene_centric_release')
+def delete_previous_coverage_by_gene_centric_release(release_id: str, color: str, skip=None):
+    delete_previous_release('coverage_by_gene_centric', release_id, color, skip=skip)
+    
 @task(task_id='test_duplicated_by_url')
 def test_duplicated_by_url(url, skip=None):
     if skip:

--- a/dags/lib/tasks/es.py
+++ b/dags/lib/tasks/es.py
@@ -18,7 +18,8 @@ def get_previous_release(release: str, n: int = 2):
     return previous_release
 
 
-def delete_previous_release(index_name: str, release_id: str, under_color: str, skip=None):
+@task(task_id='delete_previous_release')
+def delete_previous_release(index_name: str, release_id: str, color: str, skip=None):
     if skip:
         raise AirflowSkipException()
 
@@ -26,37 +27,13 @@ def delete_previous_release(index_name: str, release_id: str, under_color: str, 
 
     logging.info(f'Delete previous release for index: {index_name} {previous_release}')
 
-    response = requests.delete(f'{es_url}/clin_{env}{under_color}_{index_name}_{previous_release}?ignore_unavailable=true', verify=False)
+    response = requests.delete(f'{es_url}/clin_{env}{color}_{index_name}_{previous_release}?ignore_unavailable=true', verify=False)
     logging.info(f'ES response:\n{response.text}')
 
     if not response.ok:
         raise AirflowFailException('Failed')
 
     return
-
-@task(task_id='gene_centric_release')
-def delete_previous_gene_centric_release(release_id: str, color: str, skip=None):
-    delete_previous_release('gene_centric', release_id, color, skip=skip)
-
-@task(task_id='gene_suggestions_release')
-def delete_previous_gene_suggestions_release(release_id: str, color: str, skip=None):
-    delete_previous_release('gene_suggestions', release_id, color, skip=skip)
-
-@task(task_id='variant_centric_release')
-def delete_previous_variant_centric_release(release_id: str, color: str, skip=None):
-    delete_previous_release('variant_centric', release_id, color, skip=skip)
-
-@task(task_id='variant_suggestions_release')
-def delete_previous_variant_suggestions_release(release_id: str, color: str, skip=None):
-    delete_previous_release('variant_suggestions', release_id, color, skip=skip)
-
-@task(task_id='cnv_centric_release')
-def delete_previous_cnv_centric_release(release_id: str, color: str, skip=None):
-    delete_previous_release('cnv_centric', release_id, color, skip=skip)
-
-@task(task_id='coverage_by_gene_centric_release')
-def delete_previous_coverage_by_gene_centric_release(release_id: str, color: str, skip=None):
-    delete_previous_release('coverage_by_gene_centric', release_id, color, skip=skip)
     
 @task(task_id='test_duplicated_by_url')
 def test_duplicated_by_url(url, skip=None):

--- a/dags/lib/tasks/es.py
+++ b/dags/lib/tasks/es.py
@@ -34,27 +34,27 @@ def delete_previous_release(index_name: str, release_id: str, under_color: str, 
 
     return
 
-@task(task_id='delete_previous_gene_centric_release')
+@task(task_id='gene_centric_release')
 def delete_previous_gene_centric_release(release_id: str, color: str, skip=None):
     delete_previous_release('gene_centric', release_id, color, skip=skip)
 
-@task(task_id='delete_previous_gene_suggestions_release')
+@task(task_id='gene_suggestions_release')
 def delete_previous_gene_suggestions_release(release_id: str, color: str, skip=None):
     delete_previous_release('gene_suggestions', release_id, color, skip=skip)
 
-@task(task_id='delete_previous_variant_centric_release')
+@task(task_id='variant_centric_release')
 def delete_previous_variant_centric_release(release_id: str, color: str, skip=None):
     delete_previous_release('variant_centric', release_id, color, skip=skip)
 
-@task(task_id='delete_previous_variant_suggestions_release')
+@task(task_id='variant_suggestions_release')
 def delete_previous_variant_suggestions_release(release_id: str, color: str, skip=None):
     delete_previous_release('variant_suggestions', release_id, color, skip=skip)
 
-@task(task_id='delete_previous_cnv_centric_release')
+@task(task_id='cnv_centric_release')
 def delete_previous_cnv_centric_release(release_id: str, color: str, skip=None):
     delete_previous_release('cnv_centric', release_id, color, skip=skip)
 
-@task(task_id='delete_previous_coverage_by_gene_centric_release')
+@task(task_id='coverage_by_gene_centric_release')
 def delete_previous_coverage_by_gene_centric_release(release_id: str, color: str, skip=None):
     delete_previous_release('coverage_by_gene_centric', release_id, color, skip=skip)
     


### PR DESCRIPTION
Small changes (improvements?) to PROD behavior:

- [x] `etl` dag now perform `etl_cnv_frequencies` (after, when batch already imported)
- [x] `etl` dag now`delete_previous_releases` after an import (instead of doing it manullay via `etl_es_utils`)
- [x] New dag `etl_delete_previous_releases` for manual delete

Schedules DAGs that can now be disabled:

- [x] Disable `etl_cnv_frequencies` daily schedule
- [x] Disable `etl_qc_es` daily schedule ( was checking ES disk space, also done in `etl`)