### PR TITLE
feat: CLIN-3410 adjust nextflow post processing pipeline inputs and o…

### DIFF
--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -41,7 +41,8 @@ with DAG(
         on_success_callback=Slack.notify_dag_start
     )
 
-    params_validate = validate_color(color=color())
+    # Disabling callback as the start task already perform the slack notification
+    params_validate = validate_color.override(on_success_callback=None)(color=color())
 
     ingest_fhir_group = ingest_fhir(
         batch_id='',  # No associated "batch"

--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -34,7 +34,7 @@ nextflow_post_processing_params_file = f"{nextflow_post_processing_config_map.mo
 ##################################
 nextflow_svclustering_revision = 'v1.3.0-clin'
 nextflow_svclustering_parental_origin_revision = 'v1.1.1-clin'
-nextflow_post_processing_revision = 'v2.7.0'
+nextflow_post_processing_revision = 'v2.8.0'
 
 #######################################
 # Define nextflow pipeline names here #
@@ -47,8 +47,10 @@ nextflow_post_processing_pipeline = 'Ferlab-Ste-Justine/Post-processing-Pipeline
 # Define nextflow input and output file configurations here #
 #############################################################
 nextflow_bucket = config.clin_datalake_bucket
-nextflow_exomiser_input_key = lambda analysis_id: f'nextflow/exomiser_input/{analysis_id}.pheno.json'
+nextflow_exomiser_input_key = lambda analysis_id: f'nextflow/exomiser/input/{analysis_id}.pheno.json'
 nextflow_svclustering_parental_origin_input_key = lambda batch_id: \
     f'nextflow/svclustering_parental_origin_input/{batch_id}/{batch_id}.csv'
-nextflow_post_processing_input_key = lambda _hash: f'nextflow/post_processing_input/{_hash}.samplesheet.csv'
-nextflow_post_processing_output_key = lambda _hash: f'nextflow/post_processing_output/{_hash}'  # _hash here can be a template
+nextflow_post_processing_input_key = lambda _hash: f'nextflow/post_processing/input/{_hash}.samplesheet.csv'
+nextflow_post_processing_info_output_key = lambda _hash: f'nextflow/post_processing/output/runs/{_hash}'  # _hash here can be a template
+nextflow_post_processing_vep_output_key = 'nextflow/post_processing/output/ensemblvep'
+nextflow_post_processing_exomiser_output_key = 'nextflow/post_processing/output/exomiser'

--- a/dags/lib/tasks/nextflow/post_processing.py
+++ b/dags/lib/tasks/nextflow/post_processing.py
@@ -7,7 +7,9 @@ from lib.config_nextflow import (
     nextflow_post_processing_pipeline, nextflow_post_processing_revision,
     nextflow_post_processing_config_file, nextflow_post_processing_config_map,
     nextflow_post_processing_params_file,
-    nextflow_post_processing_output_key
+    nextflow_post_processing_info_output_key,
+    nextflow_post_processing_vep_output_key,
+    nextflow_post_processing_exomiser_output_key
 )
 from lib.config_operators import nextflow_base_config
 from lib.datasets import enriched_clinical
@@ -97,8 +99,10 @@ def run(input: str, job_hash: str, skip: str = '', **kwargs):
     :param job_hash: Unique hash for the job
     :param skip: Skip the task
     """
-    output_s3_key = nextflow_post_processing_output_key(job_hash)
-    output_dir = f"s3://{nextflow_bucket}/{output_s3_key}"
+    info_output_s3_key = nextflow_post_processing_info_output_key(job_hash)
+    info_output_dir = f's3://{nextflow_bucket}/{info_output_s3_key}'
+    vep_output_dir = f's3://{nextflow_bucket}/{nextflow_post_processing_vep_output_key}'
+    exomiser_output_dir = f's3://{nextflow_bucket}/{nextflow_post_processing_exomiser_output_key}'
 
     return nextflow_base_config \
         .with_pipeline(nextflow_post_processing_pipeline) \
@@ -108,7 +112,9 @@ def run(input: str, job_hash: str, skip: str = '', **kwargs):
         .with_params_file(nextflow_post_processing_params_file) \
         .append_args(
             '--input', input,
-            '--outdir', output_dir
+            '--outdir', info_output_dir,
+            '--vep_outdir', vep_output_dir,
+            '--exomiser_outdir', exomiser_output_dir,
         ) \
         .operator(
             NextflowOperator,


### PR DESCRIPTION
## 📌 Summary

This PR adjusts the input and output paths for the Nextflow post-processing pipeline to align with the structure described in CLIN-3410.

Here is the expected file structure:
```
cqgc-qa-app-datalake/nextflow/
     |_ exomiser/input/
             ANALYSIS_ID.pheno.json
     |_ post_processing/
             |_ input/
                  JOB_HASH.samplesheet.csv
             |_ output/
                   |_ runs/JOB_HASH/
                         |_ pipeline_info/
                         |_ bcftools/
                          ... 
                   |_ ensemblvep/
                          ANALYSIS_ID.snv.norm.VEP.vcf.gz
                          ANALYSIS_ID.snv.norm.VEP.vcf.gz.tbi
                   |_ exomiser/
                          ANALYSIS_ID.exomiser.genes.tsv
                          ANALYSIS_ID.exomiser.variants.tsv
                          ANALYSIS_ID.exomiser.html
                          ANALYSIS_ID.exomiser.json
                          ANALYSIS_ID.exomiser.vcf.gz
                          ANALYSIS_ID.exomiser.vcf.gz.tbi
```                                                                        
                                                                                                                                 

The post-processing pipeline's inputs and outputs are now organized under a single parent folder: cqgc-qa-app-datalake/nextflow/post_processing.  Note that, for now, the datalake bucket is still being used, as the dedicated nextflow bucket has not yet been created. This will be addressed in a separate ticket.

We remove the job hash in vep and exomiser outputs.  One should be able to infer the paths directly from the analysis ID and no duplicate files should exist for the same analysis id.

Secondary pipeline outputs meant for monitoring or debugging will continue to be saved in paths named after the JOB_HASH, as before (here cqgc-qa-app-datalake/nextflow/post_processing/runs/JOB_HASH) .

We also renamed the exomiser input subfolder to  `/exomiser/input` for consistency, even though exomiser is not a pipeline.


## 🛠️ Changes
- ✨ Updated pipeline input and output paths as specified in CLIN-3410.
- 🐞 Fixed an issue to prevent duplicate Slack notifications when starting the DAG.

## 🧪 Tests

Note: The bug fix for duplicate slack notification will be tested directly in QA when this pull request is merged.

Launched the etl_run dag in QA from the present feature branch. The fhir tasks were skipped by manually tweaking the dag. 
Checked that the input and output data are at the expected location.

Inspecting the data (truncated a few command outputs for concision):
```
aws s3 ls s3://cqgc-qa-app-datalake/nextflow/exomiser/input/ --profile nf-cqgc-qa
2025-04-04 12:13:16        450 2486333.pheno.json
2025-04-04 12:13:16        626 2486369.pheno.json
2025-04-04 12:13:16        802 2486428.pheno.json
2025-04-04 12:13:16       1198 2486697.pheno.json
2025-04-04 12:13:16        909 2512790.pheno.json

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/ --profile nf-cqgc-qa
                           PRE input/
                           PRE output/

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/input/ --profile nf-cqgc-qa
2025-04-04 12:13:21       1968 OReKPdwJQTblxB.samplesheet.csv

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/output/
                           PRE ensemblvep/
                           PRE exomiser/
                           PRE runs/
                           
aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/output/ensemblvep/ --profile nf-cqgc-qa
2025-04-04 12:22:46          0 
2025-04-04 12:21:47      34232 variants.2486333.snv.norm.VEP.vcf.gz
2025-04-04 12:22:46       1139 variants.2486333.snv.norm.VEP.vcf.gz.tbi
... (TRUNCATED)

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/output/exomiser/ --profile nf-cqgc-qa
2025-04-04 12:27:46          0 
2025-04-04 12:27:46        373 2486333.exomiser.genes.tsv
2025-04-04 12:27:46     135684 2486333.exomiser.html
2025-04-04 12:27:46          2 2486333.exomiser.json
2025-04-04 12:27:46        610 2486333.exomiser.variants.tsv
2025-04-04 12:27:46      25857 2486333.exomiser.vcf.gz
2025-04-04 12:27:46         72 2486333.exomiser.vcf.gz.tbi
... (TRUNCATED)

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/output/runs/ --profile nf-cqgc-qa
                           PRE OReKPdwJQTblxB/

aws s3 ls s3://cqgc-qa-app-datalake/nextflow/post_processing/output/runs/OReKPdwJQTblxB/ --profile nf-cqgc-qa
                           PRE bcftools/
                           PRE combinegvcfs/
                           PRE gatk4/
                           PRE pipeline_info/
                           PRE splitmultiallelics/
2025-04-04 12:13:45          0 
```



## 🔗 Related Issues
-  https://ferlab-crsj.atlassian.net/browse/CLIN-3410

[CLIN-3410]: https://ferlab-crsj.atlassian.net/browse/CLIN-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
