### PR TITLE
fix: CLIN-3410 fix duplicated slack notification on start

### DIFF
--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -42,7 +42,7 @@ with DAG(
     )
 
     # Disabling callback as the start task already perform the slack notification
-    params_validate = validate_color.override(on_success_callback=None)(color=color())
+    params_validate = validate_color.override(on_execute_callback=None)(color=color())
 
     ingest_fhir_group = ingest_fhir(
         batch_id='',  # No associated "batch"


### PR DESCRIPTION
Small correction to avoid duplicated slack notifications when starting the dag.

The `on_execute_callback` attribute defined in the `@task(task_id='params_validate', on_execute_callback=Slack.notify_dag_start)` annotation needs to be overridden. 

Previously, we were overriding `on_success_callback` attribute instead, which had no effect in this case.