### PR TITLE
refactor: CLIN-4321 refactor batch type detection

### DIFF
--- a/dags/lib/tasks/batch_type.py
+++ b/dags/lib/tasks/batch_type.py
@@ -1,12 +1,19 @@
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 from lib.config import s3_conn_id, clin_import_bucket
-from lib.utils_etl import metadata_exists, get_metadata_content, ClinSchema, ClinAnalysis, ClinVCFSuffix
+from lib.datasets import enriched_clinical
+from lib.utils_etl import (
+    metadata_exists,
+    get_metadata_content,
+    ClinSchema,
+    ClinAnalysis,
+    ClinVCFSuffix
+)
 
 
 def _validate_snv_vcf_files(s3: S3Hook, batch_id: str, snv_suffix: str):
@@ -46,10 +53,103 @@ def _validate_cnv_vcf_files(metadata: dict, cnv_suffix: str):
         raise AirflowFailException(f'Not all valid CNV VCF(s) found')
 
 
-@task(task_id='detect_batch_type')
-def detect(batch_id: str) -> Dict[str, str]:
+# Preserving the old function name and task ID for backward compatibility.
+# In the future, we may consider renaming this to remove references to the batch concept.
+@task.virtualenv(task_id='detect_batch_type', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+def detect(batch_id: Optional[str] = None, sequencing_ids: Optional[List[str]] = None) -> Dict[str, str]:
     """
-    Returns a dict where the key is the batch id and the value is the batch type.
+    Returns a dict where the key is the batch id or the sequencing id and the value is the analysis type.
+
+    Here batch_id and sequencing_ids are mutually exclusive. If both are provided, an exception will be raised.
+
+    If a `batch_id` is provided and the analysis type cannot be determined from the `enriched_clinical` table,
+    the function will attempt to infer the analysis type from the metadata file. If the metadata file does
+    not exist, the analysis type will default to `SOMATIC_TUMOR_NORMAL`.
+
+    The possible analysis types (formerly referred to as batch type) are:
+        - GERMLINE
+        - SOMATIC_TUMOR_ONLY
+        - SOMATIC_TUMOR_NORMAL
+    """
+    import logging
+    from airflow.exceptions import AirflowFailException
+    from lib.tasks.batch_type import _detect_type_from_enrich_clinical, _detect_type_from_metadata_file
+
+    logger = logging.getLogger(__name__)
+
+    if batch_id and sequencing_ids:
+        raise AirflowFailException("Only one of batch_id or sequencing_ids can be provided")
+
+    if not (batch_id or sequencing_ids):
+        raise AirflowFailException("Either batch_id or sequencing_ids must be provided")
+
+    identifier_to_type = _detect_type_from_enrich_clinical(
+        identifier_column="batch_id" if batch_id else "service_request_id",
+        identifiers=[batch_id] if batch_id else sequencing_ids,
+        must_exist=bool(sequencing_ids)
+    )
+    if not identifier_to_type and batch_id:
+        logger.info(f"Unable to infer batch type for batch ID {batch_id} from the enriched clinical table. Falling back to metadata file.")
+        return _detect_type_from_metadata_file(batch_id)
+    else:
+        return identifier_to_type
+
+
+def _detect_type_from_enrich_clinical(identifier_column, identifiers, must_exist=True):
+    """
+    Returns a dictionary mapping each identifier to its corresponding analysis type.
+
+    The possible analysis types (formerly referred to as batch type) are:
+     - GERMLINE
+     - SOMATIC_TUMOR_ONLY
+     - SOMATIC_TUMOR_NORMAL
+
+    The identifiers provided must match the values in the specified `identifier_column`
+    of the `enriched_clinical` table.
+    """
+    from collections import defaultdict
+    from airflow.exceptions import AirflowFailException
+    from pandas import DataFrame
+    from lib.datasets import enriched_clinical
+    from lib.utils_etl import BioinfoAnalysisCode
+    from lib.utils_etl_tables import to_pandas
+
+    df: DataFrame = (
+        to_pandas(enriched_clinical.uri)
+        .filter([identifier_column, "bioinfo_analysis_code"])
+        .set_index(identifier_column)
+    )
+    distinct_pairs_df = df[df.index.isin(identifiers)].drop_duplicates()
+
+    identifier_to_codes = defaultdict(list)
+    for _id, code in distinct_pairs_df.itertuples():
+        identifier_to_codes[_id].append(code)
+
+    identifiers_with_multiple_codes = {k: v for k, v in identifier_to_codes.items() if len(v) > 1}
+    if identifiers_with_multiple_codes:
+        raise AirflowFailException(f"Multiple bioinfo_analysis_code found for some identifiers: {identifiers_with_multiple_codes}")
+
+    identifiers_with_unknown_codes = {k: v for k, v in identifier_to_codes.items() if v[0] not in BioinfoAnalysisCode}
+    if identifiers_with_unknown_codes:
+        raise AirflowFailException(f"Some identifiers map to unknown codes: {identifiers_with_unknown_codes}")
+
+    if must_exist:
+        missing_identifiers = set(identifiers) - set(identifier_to_codes.keys())
+        if missing_identifiers:
+            raise AirflowFailException(f"IDs not found in clinical data: {missing_identifiers}")
+
+    identifier_to_type = {k: BioinfoAnalysisCode[v[0]].to_analysis_type() for k, v in identifier_to_codes.items()}
+    return identifier_to_type
+
+
+def _detect_type_from_metadata_file(batch_id: str) -> Dict[str, str]:
+    """
+    Returns a dict where the key is the batch id and the value is the analysis type.
+
+    The possible analysis types (formerly referred to as batch type) are:
+     - GERMLINE
+     - SOMATIC_TUMOR_ONLY
+     - SOMATIC_TUMOR_NORMAL
     """
     clin_s3 = S3Hook(s3_conn_id)
 

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -27,6 +27,20 @@ class ClinSchema(Enum):
     SOMATIC_TUMOR_ONLY = 'CQGC_Exome_Tumeur_Seul'
 
 
+class BioinfoAnalysisCode(Enum):
+    GEBA = 'GEBA'
+    TEBA = 'TEBA'
+    TNEBA = 'TNEBA'
+
+    def to_analysis_type(self) -> str:
+        mapping = {
+            BioinfoAnalysisCode.GEBA: ClinAnalysis.GERMLINE.value,
+            BioinfoAnalysisCode.TEBA: ClinAnalysis.SOMATIC_TUMOR_ONLY.value,
+            BioinfoAnalysisCode.TNEBA: ClinAnalysis.SOMATIC_TUMOR_NORMAL.value
+        }
+        return mapping[self]
+
+
 def batch_id() -> str:
     return '{{ params.batch_id or "" }}'
 


### PR DESCRIPTION
## 📌 Summary
This pull request updates the logic for detecting batch types in etl.py to remove the dependency on the metadata.json file stored in S3. This change ensures compatibility with both batch imports and API imports, where the metadata.json file will no longer be available.

## 🛠️ Changes

**Batch Type Detection**
The detect logic now queries the `enriched_clinical` table to determine batch types.

Inputs:
 - batch_id (same column name in clinical).
-  sequencing_ids (corresponds to the service_request_id column in clinical).

 Batch type obtained via column `bioinfo_analysis_code`
    GEBA → GERMLINE
    TEBA → SOMATIC_TUMOR_ONLY
    TNEBA → SOMATIC_TUMOR_NORMAL
 
**Fallback Logic**
If batch_id is provided but no results are found in the clinical table (e.g., the batch has not yet been imported), the logic falls back to the current method of reading metadata.json from S3.

**Validations and assumptions**
- We assume that the batch_id and sequencing_ids inputs are mutually exclusive, meaning that only one of them can be provided at a time. If both are provided, an exception is thrown.
- The code includes validation to ensure that a single bioinfo_analysis_code is retrieved for each sequencing_id or batch_id.

## 🧪 Tests

### Panda logic
✅  Execute the panda logic in a shell to make sure that it works as expected

### airflow + minio installed locally

Airflow and minio are deployed in a local kubernetes cluster.

The enrich_clinical table from qa was copied in the local minio.
A metadata.json file for a single batch (Dragen_Trios) was also copied.

A test dag is used to call the airflow task with different combinations of sequencing ids and batch id.

✅  germinal batch in  enrich_clinical:
batch_id  = 2_data_to_import_germinal
xcom:  {'2_data_to_import_germinal': 'germline'}

✅  batch NOT in enrich_clinical, no metadata file:  expecting fallback to  'somatic_tumor_normal'
batch_id = foo
xcom: {'foo': 'somatic_tumor_normal'}

✅  batch NOT in enrich_clinical, metadata file present
batch_id = Dragen_Trios
xcom: {'Dragen_Trios': 'germline'}

✅  somatic batch in enrich_clinical (TEBA):
batch_id = 3_data_to_import_somatic
xcom: {'3_data_to_import_somatic': 'somatic_tumor_only'}

✅  somatic normal batch in enrich_clinical (TNEBA):
batch_id = 4_data_to_import_somatic_normal
xcom: {'4_data_to_import_somatic_normal': 'somatic_tumor_normal'}

✅  batch matching 2 different bioinfo_analysis_code : should fail
batch_id = 1_data_to_import_germinal
airflow.exceptions.AirflowFailException: Multiple bioinfo_analysis_code found for some identifiers: {'1_data_to_import_germinal': ['GEBA', 'TEBA']}

✅  sequencing ids in enrich clinical, one germinal (GEBA), one somatic (TEBA):
Sequencing ids = [xxxxx82, xxxxx43] 
xcom: {'xxxxx82': 'germline', 'xxxxx43': 'somatic_tumor_only'}

✅  one sequencing id missing in enrich clinical: should fail
sequencing ids = [xxxxx82, foo, xxxxx43] 
airflow.exceptions.AirflowFailException: IDs not found in clinical data: {'foo'}

✅  all sequencing ids missing in enrich clinical: should fail
sequencing ids = [foo]
airflow.exceptions.AirflowFailException: IDs not found in clinical data: {'foo'}

✅  sequencing id with 2 matching bioinfo_analysis_code: should fail
sequencing_ids = [xxxxx58]
airflow.exceptions.AirflowFailException: Multiple bioinfo_analysis_code found for some identifiers: {'xxxxx58': ['TEBA', 'TNEBA']}

✅  both sequencing_ids and batch_id specified: should fail
airflow.exceptions.AirflowFailException: Only one of batch_id or sequencing_ids can be provided

✅ no sequencing_ids specified and no batch_id specified: should fail
airflow.exceptions.AirflowFailException: Either batch_id or sequencing_ids must be provided

NOT COVERED: 
- somatic normal sequencing id : 
The only one available in QA match 2 bioinfo_analysis_code. The associated code branch is covered anyway through the somatic batch case, which is reusing the same code.

- unknown bioinfo_analysis_code:
There are no unknown codes in the QA table, so we were unable to test this scenario. However, this is not a major issue, as there are likely safeguards elsewhere in the code, and this only serves as an additional layer of protection.

## 🔗 Related Issues
-  https://ferlab-crsj.atlassian.net/browse/CLIN-4321

## Test Notes
[test_detect_batch_type.tar.gz](https://github.com/user-attachments/files/20015299/test_detect_batch_type.tar.gz)
