### PR TITLE
feat: CLIN-4412 update ferlab-svclustering pipeline version to 1.3.1

### DIFF
--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -32,7 +32,7 @@ nextflow_post_processing_params_file = f"{nextflow_post_processing_config_map.mo
 ##################################
 # Define nextflow revisions here #
 ##################################
-nextflow_svclustering_revision = 'v1.3.0-clin'
+nextflow_svclustering_revision = 'v1.3.1-clin'
 nextflow_svclustering_parental_origin_revision = 'v1.1.1-clin'
 nextflow_post_processing_revision = 'v2.8.0'
 


### PR DESCRIPTION
## 📌 Summary

This pull request update the version of the ferlab-svclustering nextflow pipeline to 1.3.1.
It will allow to benefit from a recent improvement on the pipeline regarding error handline.

## 🛠️ Changes
- ✨ ferlab-svclustering pipeline version updated to 1.3.1

## 🧪 Tests

We shall test directly in the QA environment. More precisely, we will run the dag etl_cnv_frequencies once this pull request is merged.

## 🔗 Related Issues
-  https://ferlab-crsj.atlassian.net/browse/CLIN-4412