### PR TITLE
feat:CLIN-4404-add-nextflow-task-for-cnv-post-processing-pipeline

### DIFF
--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -29,12 +29,21 @@ nextflow_post_processing_config_map = ConfigMap(
 nextflow_post_processing_config_file = f"{nextflow_post_processing_config_map.mount_path}/postprocessing.config"
 nextflow_post_processing_params_file = f"{nextflow_post_processing_config_map.mount_path}/postprocessing-params.json"
 
+nextflow_cnv_post_processing_config_map = ConfigMap(
+    name='nextflow-cnv-postprocessing',
+    mount_path='/root/nextflow/config/cnv-postprocessing'
+)
+nextflow_cnv_post_processing_config_file = f"{nextflow_cnv_post_processing_config_map.mount_path}/cnv-postprocessing.config"
+nextflow_cnv_post_processing_params_file = f"{nextflow_cnv_post_processing_config_map.mount_path}/cnv-postprocessing-params.json"
+
+
 ##################################
 # Define nextflow revisions here #
 ##################################
 nextflow_svclustering_revision = 'v1.3.1-clin'
 nextflow_svclustering_parental_origin_revision = 'v1.1.1-clin'
 nextflow_post_processing_revision = 'v2.8.0'
+nextflow_cnv_post_processing_revision = 'v1.0.0'
 
 #######################################
 # Define nextflow pipeline names here #
@@ -42,15 +51,23 @@ nextflow_post_processing_revision = 'v2.8.0'
 nextflow_svclustering_pipeline = 'Ferlab-Ste-Justine/ferlab-svclustering'
 nextflow_svclustering_parental_origin_pipeline = 'Ferlab-Ste-Justine/ferlab-svclustering-parental-origin'
 nextflow_post_processing_pipeline = 'Ferlab-Ste-Justine/Post-processing-Pipeline'
+nextflow_cnv_post_processing_pipeline = 'Ferlab-Ste-Justine/cnv-post-processing'
+
 
 #############################################################
 # Define nextflow input and output file configurations here #
 #############################################################
 nextflow_bucket = config.clin_datalake_bucket
 nextflow_exomiser_input_key = lambda analysis_id: f'nextflow/exomiser/input/{analysis_id}.pheno.json'
+
 nextflow_svclustering_parental_origin_input_key = lambda batch_id: \
     f'nextflow/svclustering_parental_origin_input/{batch_id}/{batch_id}.csv'
+
 nextflow_post_processing_input_key = lambda _hash: f'nextflow/post_processing/input/{_hash}.samplesheet.csv'
 nextflow_post_processing_info_output_key = lambda _hash: f'nextflow/post_processing/output/runs/{_hash}'  # _hash here can be a template
 nextflow_post_processing_vep_output_key = 'nextflow/post_processing/output/ensemblvep'
 nextflow_post_processing_exomiser_output_key = 'nextflow/post_processing/output/exomiser'
+
+nextflow_cnv_post_processing_input_key = lambda _hash: f'nextflow/cnv_post_processing/input/{_hash}.samplesheet.csv'
+nextflow_cnv_post_processing_info_output_key = lambda _hash: f'nextflow/cnv_post_processing/output/runs/{_hash}'  # _hash here can be a template
+nextflow_cnv_post_processing_exomiser_output_key = 'nextflow/cnv_post_processing/output/exomiser'

--- a/dags/lib/tasks/nextflow/cnv_post_processing.py
+++ b/dags/lib/tasks/nextflow/cnv_post_processing.py
@@ -1,0 +1,44 @@
+from lib.config_nextflow import (
+    nextflow_bucket,
+    nextflow_cnv_post_processing_pipeline,
+    nextflow_cnv_post_processing_revision,
+    nextflow_cnv_post_processing_config_file,
+    nextflow_cnv_post_processing_config_map,
+    nextflow_cnv_post_processing_params_file,
+    nextflow_cnv_post_processing_info_output_key,
+    nextflow_cnv_post_processing_exomiser_output_key
+)
+from lib.config_operators import nextflow_base_config
+from lib.operators.nextflow import NextflowOperator
+
+
+def run(input: str, job_hash: str, skip: str = '', **kwargs):
+    """
+    Executes the Nextflow post-processing pipeline.
+
+    :param input: S3 path of the samplesheet file
+    :param job_hash: Unique hash for the job
+    :param skip: Skip the task
+    """
+    info_output_s3_key = nextflow_cnv_post_processing_info_output_key(job_hash)
+    info_output_dir = f's3://{nextflow_bucket}/{info_output_s3_key}'
+    exomiser_output_dir = f's3://{nextflow_bucket}/{nextflow_cnv_post_processing_exomiser_output_key}'
+
+    return nextflow_base_config \
+        .with_pipeline(nextflow_cnv_post_processing_pipeline) \
+        .with_revision(nextflow_cnv_post_processing_revision) \
+        .append_config_maps(nextflow_cnv_post_processing_config_map) \
+        .append_config_files(nextflow_cnv_post_processing_config_file) \
+        .with_params_file(nextflow_cnv_post_processing_params_file) \
+        .append_args(
+            '--input', input,
+            '--outdir', info_output_dir,
+            '--exomiser_outdir', exomiser_output_dir,
+        ) \
+        .operator(
+            NextflowOperator,
+            task_id='cnv_post_processing',
+            name='cnv_post_processing',
+            skip=skip,
+            **kwargs
+        )

--- a/dags/test_nextflow_cnv_post_processing.py
+++ b/dags/test_nextflow_cnv_post_processing.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+
+from lib import config
+from lib.config import env, Env
+from lib.slack import Slack
+
+from lib.tasks.nextflow import cnv_post_processing
+
+DEFAULT_INPUT_FILE = f"s3://cqgc-{env}-app-files-import/test_analysis/clin-4404-cnv-post-processing-test-dag/datasets/dragen_4_2_4_small/samplesheet.csv"
+DEFAULT_JOB_HASH = "test_dragen_4_2_4_small"
+
+if config.show_test_dags and env == Env.QA:
+    with DAG(
+            dag_id="test_nextflow_cnv_post_processing",
+            start_date=datetime(2022, 1, 1),
+            schedule=None,
+            description="DAG for testing the nextflow cnv post processing task",
+            params={
+                'input': Param(
+                    DEFAULT_INPUT_FILE,
+                    type='string',
+                    description='The input samplesheet file to process.'
+                ),
+                'job_hash': Param(
+                    DEFAULT_JOB_HASH,
+                    type='string',
+                    description='Unique identifier for the job. Will be used to name the output directory.'
+                ),
+            },
+            render_template_as_native_obj=True
+    ) as dag:
+        cnv_post_processing.run(
+            input="{{ params.input }}",
+            job_hash="{{ params.job_hash }}",
+            on_execute_callback=Slack.notify_dag_start,
+            on_success_callback=Slack.notify_dag_completion
+        )


### PR DESCRIPTION
## 📌 Summary

This pull request introduces a nextflow task to launch the `cnv-post-processing` pipeline.

A test DAG (`test_nextflow_cnv_post_processing.py`) is included to validate the task. The test DAG is configured to appear only in the QA environment when the `show_test_dags` variable is set to true.

Note:
- For now, the output files are stored under `cqgc-qa-app-datalake/nextflow`, consistent with the other pipelines.
We considered using the new nextflow bucket (cqgc-qa-app-nextflow) immediately, but this change is delicate as it requires modifying configurations shared by multiple pipelines. To ensure proper tracking and QA, we propose updating the global nextflow bucket configuration in a separate pull request.

## 🛠️ Changes
 - new nextflow task to launch cnv-post-processing pipeline
 - new dag test_nextflow_cnv_post_processing.py

## 🧪 Tests

Successfully executed the dag from local computer, pointing on the CLIN QA cluster environment.

We can see output files in the expected folder. More precisely, the pipeline_info output folder is at this location:
s3://cqgc-qa-app-datalake/nextflow/cnv_post_processing/output/runs/test_dragen_4_2_4_small/pipeline_info

Here `test_dragen_4_2_5_small` was the hash id passed to the task.

The exomiser output folder is at this location:
s3://cqgc-qa-app-datalake/nextflow/cnv_post_processing/output/exomiser


## 🔗 Related Issues
-  https://ferlab-crsj.atlassian.net/browse/CLIN-4404
