### PR TITLE
fix: CLIN-4321 avoid running detect_batch_type map tasks in parallel

### DIFF
--- a/dags/lib/tasks/batch_type.py
+++ b/dags/lib/tasks/batch_type.py
@@ -55,7 +55,8 @@ def _validate_cnv_vcf_files(metadata: dict, cnv_suffix: str):
 
 # Preserving the old function name and task ID for backward compatibility.
 # In the future, we may consider renaming this to remove references to the batch concept.
-@task.virtualenv(task_id='detect_batch_type', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+# Note that we restrict amount of activate mapped tasks per DAG to avoid memory issues and delta lake connection problems.
+@task.virtualenv(task_id='detect_batch_type', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
 def detect(batch_id: Optional[str] = None, sequencing_ids: Optional[List[str]] = None) -> Dict[str, str]:
     """
     Returns a dict where the key is the batch id or the sequencing id and the value is the analysis type.


### PR DESCRIPTION

## Description
We observed instability with the `detect_batch_type` task when parallel execution was allowed. 

To address this, we introduce a restriction to ensure that only one instance of the task runs at a time.

This change aims to improve stability by avoiding potential issues such as memory overload or Delta Lake connection problems.

## Changes
- We set the parameter `max_active_tis_per_dag` to `1` on task `detect_batch_type` to force sequential execution

## Tests
- Execute the task locally via a test dag and verify that it can still be executed succesfully ✅ 
- Execute the begginning of the etl.run dag, until detect_batch_type task locally.  Check that the detect_batch_type tasks are run sequentially. ✅ 

## Links
Airflow documentation:
https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/dynamic-task-mapping.html#placing-limits-on-mapped-tasks

JIRA ticket:
https://ferlab-crsj.atlassian.net/browse/CLIN-4321