### PR TITLE
feat: CLIN-4284 move nextflow pipelines inputs and outputs to nextflow bucket

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -49,6 +49,7 @@ svclustering_batch_size = Variable.get('svclustering_batch_size', 100)
 
 clin_import_bucket = f'cqgc-{env}-app-files-import'
 clin_datalake_bucket = f'cqgc-{env}-app-datalake'
+clin_nextflow_bucket = f'cqgc-{env}-app-nextflow'
 clin_scratch_bucket = f'cqgc-{env}-app-files-scratch'
 
 arranger_image = 'ferlabcrsj/clin-arranger:1.3.3'
@@ -113,7 +114,7 @@ elif env == Env.PROD:
     pipeline_image = 'ferlabcrsj/clin-pipelines:bb6aad0'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'https://workers.search.cqgc.hsj.rtss.qc.ca:9200'
-    spark_jar = 'clin-variant-etl-v3.10.2.jar'
+    spark_jar = 'clin-variant-etl-v3.11.0.jar'
     obo_parser_spark_jar = 'obo-parser-v1.1.0.jar'
     ca_certificates = 'ca-certificates-bundle'
     minio_certificate = 'ca-certificates-bundle'

--- a/dags/lib/config_nextflow.py
+++ b/dags/lib/config_nextflow.py
@@ -57,17 +57,22 @@ nextflow_cnv_post_processing_pipeline = 'Ferlab-Ste-Justine/cnv-post-processing'
 #############################################################
 # Define nextflow input and output file configurations here #
 #############################################################
-nextflow_bucket = config.clin_datalake_bucket
-nextflow_exomiser_input_key = lambda analysis_id: f'nextflow/exomiser/input/{analysis_id}.pheno.json'
+nextflow_bucket = config.clin_nextflow_bucket
+nextflow_exomiser_input_key = lambda analysis_id: f'exomiser/input/{analysis_id}.pheno.json'
+
+nextflow_svclustering_input_key = 'svclustering/input/input.csv'
+nextflow_svclustering_output_key = 'svclustering/output'
 
 nextflow_svclustering_parental_origin_input_key = lambda batch_id: \
-    f'nextflow/svclustering_parental_origin_input/{batch_id}/{batch_id}.csv'
+    f'svclustering_parental_origin/input/{batch_id}/{batch_id}.csv'
+nextflow_svclustering_parental_origin_output_key = lambda batch_id: \
+    f'svclustering_parental_origin/output/{batch_id}'
 
-nextflow_post_processing_input_key = lambda _hash: f'nextflow/post_processing/input/{_hash}.samplesheet.csv'
-nextflow_post_processing_info_output_key = lambda _hash: f'nextflow/post_processing/output/runs/{_hash}'  # _hash here can be a template
-nextflow_post_processing_vep_output_key = 'nextflow/post_processing/output/ensemblvep'
-nextflow_post_processing_exomiser_output_key = 'nextflow/post_processing/output/exomiser'
+nextflow_post_processing_input_key = lambda _hash: f'post_processing/input/{_hash}.samplesheet.csv'
+nextflow_post_processing_info_output_key = lambda _hash: f'post_processing/output/runs/{_hash}'  # _hash here can be a template
+nextflow_post_processing_vep_output_key = 'post_processing/output/ensemblvep'
+nextflow_post_processing_exomiser_output_key = 'post_processing/output/exomiser'
 
-nextflow_cnv_post_processing_input_key = lambda _hash: f'nextflow/cnv_post_processing/input/{_hash}.samplesheet.csv'
-nextflow_cnv_post_processing_info_output_key = lambda _hash: f'nextflow/cnv_post_processing/output/runs/{_hash}'  # _hash here can be a template
-nextflow_cnv_post_processing_exomiser_output_key = 'nextflow/cnv_post_processing/output/exomiser'
+nextflow_cnv_post_processing_input_key = lambda _hash: f'cnv_post_processing/input/{_hash}.samplesheet.csv'
+nextflow_cnv_post_processing_info_output_key = lambda _hash: f'cnv_post_processing/output/runs/{_hash}'  # _hash here can be a template
+nextflow_cnv_post_processing_exomiser_output_key = 'cnv_post_processing/output/exomiser'

--- a/dags/lib/tasks/nextflow/svclustering.py
+++ b/dags/lib/tasks/nextflow/svclustering.py
@@ -1,5 +1,11 @@
-from lib.config_nextflow import nextflow_svclustering_revision, nextflow_svclustering_pipeline, nextflow_bucket, \
+from lib.config_nextflow import (
+    nextflow_svclustering_input_key,
+    nextflow_svclustering_output_key,
+    nextflow_svclustering_revision,
+    nextflow_svclustering_pipeline,
+    nextflow_bucket,
     NEXTFLOW_MAIN_CLASS
+)
 from lib.config_operators import nextflow_svclustering_base_config
 from lib.operators.nextflow import NextflowOperator
 from lib.operators.spark_etl import SparkETLOperator
@@ -25,8 +31,8 @@ def run(skip: str = '', **kwargs):
         .with_pipeline(nextflow_svclustering_pipeline) \
         .with_revision(nextflow_svclustering_revision) \
         .append_args(
-            '--input', f's3://{nextflow_bucket}/nextflow/svclustering_input/svclustering_input.csv',
-            '--outdir', f's3://{nextflow_bucket}/nextflow/svclustering_output') \
+            '--input', f's3://{nextflow_bucket}/{nextflow_svclustering_input_key}',
+            '--outdir', f's3://{nextflow_bucket}/{nextflow_svclustering_output_key}') \
         .operator(
             NextflowOperator,
             task_id='svclustering',

--- a/dags/lib/tasks/nextflow/svclustering_parental_origin.py
+++ b/dags/lib/tasks/nextflow/svclustering_parental_origin.py
@@ -1,6 +1,11 @@
-from lib.config_nextflow import nextflow_svclustering_parental_origin_revision, \
-    nextflow_svclustering_parental_origin_pipeline, nextflow_bucket, nextflow_svclustering_parental_origin_input_key, \
+from lib.config_nextflow import (
+    nextflow_svclustering_parental_origin_revision,
+    nextflow_svclustering_parental_origin_pipeline,
+    nextflow_bucket,
+    nextflow_svclustering_parental_origin_input_key,
+    nextflow_svclustering_parental_origin_output_key,
     NEXTFLOW_MAIN_CLASS
+)
 from lib.config_operators import nextflow_svclustering_base_config
 from lib.operators.nextflow import NextflowOperator
 from lib.operators.spark_etl import SparkETLOperator
@@ -28,7 +33,7 @@ def run(batch_id: str, skip: str = '', **kwargs):
         .with_revision(nextflow_svclustering_parental_origin_revision) \
         .append_args(
             '--input', f's3://{nextflow_bucket}/{nextflow_svclustering_parental_origin_input_key(batch_id)}',
-            '--outdir', f's3://{nextflow_bucket}/nextflow/svclustering_parental_origin_output/{batch_id}') \
+            '--outdir', f's3://{nextflow_bucket}/{nextflow_svclustering_parental_origin_output_key(batch_id)}') \
         .operator(
             NextflowOperator,
             task_id='svclustering_parental_origin',


### PR DESCRIPTION
## Description

This pull request move nextflow pipelines inputs and outputs to nextflow buckets.

We restrict to tables containing raw input and output data. Intermediate delta tables derived from nextflow pipelines output data are not touched.

This pull request is linked to a companion PR in clin-pipeline-dags and should be merged and deployed simultaneously: 
https://github.com/Ferlab-Ste-Justine/clin-variant-etl/pull/460

This involves our 4 nextflow pipelines:
- svclustering
- svclustering_parental_origin
- post_processing
- cnv_post_processing

To deal with already existing data, a manual migration procedure will need to be applied.  See the script migration.sh that is in the attachments on the JIRA:
https://ferlab-crsj.atlassian.net/browse/CLIN-4284

## Changes

- Update input/output pipelines paths

## Tests

- Run dags / task groups associated to each pipeline locally using a manually built clin-variant-etl jar, pointing on Qlin QA environment.  The execution should be successful and pipelines input/output files should be on the nextflow bucket as exepcted.
  - svclustering pipeline: run dag etl_cnv_frequencies (only index related tasks at the end fail, likely a bad local elasticsearch setup)
  - svclustering_parental_origin: run nextflow task group from etl_ingest.py (copy pasted the logic in a test dag)
  - post-processing pipeline: run dag etl_run
  - cnv-post-processing pipeline: run dag test_nextflow_cnv_post_processing

- In QA, we will need to run the migration script and test the following dags:
etl_ingest.py (svclustering_parental_origin)
etl_cnv_frequencies (svclustering)
etl_run (post_processing)
test_nextflow_cnv_post_processing (cnv_post_processing)

## Links
Associated JIRA ticket:
https://ferlab-crsj.atlassian.net/browse/CLIN-4284

Companion pull request in clin-variant-etl:
https://github.com/Ferlab-Ste-Justine/clin-variant-etl/pull/460
