### PR TITLE
Fix deprecated Airflow code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__
 logs
 plugins
 venv
+.venv
 .idea
 doc/test/.minikube-setup

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 Create venv :
 
 ```
-python -m venv venv
+python -m venv .venv
 ```
 
 Activate venv :
 
 ```
-source venv/bin/activate
+source .venv/bin/activate
 ```
 
 Install requirements :
 
 ```
-pip install -r requirements
+pip install -r requirements.txt
 ```
 
 ## Airflow dev stack

--- a/dags/etl.py
+++ b/dags/etl.py
@@ -26,7 +26,7 @@ from lib.utils_etl import (ClinAnalysis, color, default_or_initial, release_id,
 with DAG(
         dag_id='etl',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'batch_ids': Param([], type=['null', 'array'],
                                description='Put a single batch id per line. Leave empty to skip ingest.'),

--- a/dags/etl_arranger.py
+++ b/dags/etl_arranger.py
@@ -14,7 +14,7 @@ from lib.utils_etl import color, release_id
 with DAG(
         dag_id='etl_arranger',
         start_date=datetime(2022, 1, 1),
-        schedule_interval="0 6 * * *" if env == Env.PROD else None, # 8am UTC / 2am Montreal
+        schedule="0 6 * * *" if env == Env.PROD else None, # 8am UTC / 2am Montreal
         catchup=False,
         max_active_runs=1,
         params={

--- a/dags/etl_cleanup.py
+++ b/dags/etl_cleanup.py
@@ -19,7 +19,7 @@ if env in [Env.QA, Env.STAGING]:
     with DAG(
         dag_id='etl_cleanup',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'color': Param('', type=['null', 'string']),
         },

--- a/dags/etl_cnv_frequencies.py
+++ b/dags/etl_cnv_frequencies.py
@@ -18,7 +18,7 @@ with DAG(
         dag_id='etl_cnv_frequencies',
         doc_md=doc.cnv_frequencies,
         start_date=datetime(2024, 10, 20, 2, tzinfo=pendulum.timezone("America/Montreal")),
-        schedule_interval=None,
+        schedule=None,
         params={
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),

--- a/dags/etl_delete_previous_releases.py
+++ b/dags/etl_delete_previous_releases.py
@@ -1,25 +1,20 @@
 from datetime import datetime
 
 from airflow import DAG
-from airflow.exceptions import AirflowFailException
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import task
 from airflow.utils.trigger_rule import TriggerRule
-from lib.config import K8sContext, env, es_url
+
 from lib.groups.index.delete_previous_releases import delete_previous_releases
 from lib.groups.index.get_release_ids import get_release_ids
-from lib.operators.curl import CurlOperator
 from lib.slack import Slack
-from lib.tasks import es
 from lib.tasks.params_validate import validate_color
-from lib.utils_es import format_es_url
-from lib.utils_etl import color, release_id, skip_if_param_not
+from lib.utils_etl import color, release_id
 
 with DAG(
         dag_id='etl_delete_previous_releases',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),

--- a/dags/etl_es_utils.py
+++ b/dags/etl_es_utils.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
 from airflow import DAG
+from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import task
 from airflow.utils.trigger_rule import TriggerRule
+
 from lib.config import K8sContext, env, es_url
 from lib.operators.curl import CurlOperator
 from lib.slack import Slack
@@ -17,7 +18,7 @@ from lib.utils_etl import color, release_id, skip_if_param_not
 with DAG(
         dag_id='etl_es_utils',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'delete_release': Param('no', enum=['yes', 'no']),
             'test_duplicated_variants': Param('no', enum=['yes', 'no']),

--- a/dags/etl_import_1000_genomes.py
+++ b/dags/etl_import_1000_genomes.py
@@ -16,7 +16,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_1000_genomes',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_clinvar.py
+++ b/dags/etl_import_clinvar.py
@@ -16,7 +16,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_clinvar',
     start_date=datetime(2022, 1, 1),
-    schedule_interval='0 21 * * 5',
+    schedule='0 21 * * 5',
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_cosmic.py
+++ b/dags/etl_import_cosmic.py
@@ -21,7 +21,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
         dag_id='etl_import_cosmic',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         default_args={
             'on_failure_callback': Slack.notify_task_failure,
         },

--- a/dags/etl_import_dbnsfp.py
+++ b/dags/etl_import_dbnsfp.py
@@ -14,7 +14,7 @@ from lib.slack import Slack
 with DAG(
     dag_id='etl_import_dbnsfp',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_dbsnp.py
+++ b/dags/etl_import_dbsnp.py
@@ -17,7 +17,7 @@ from lib.utils_s3 import get_s3_file_md5, download_and_check_md5, load_to_s3_wit
 with DAG(
     dag_id='etl_import_dbsnp',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_ddd.py
+++ b/dags/etl_import_ddd.py
@@ -17,7 +17,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_ddd',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_ensembl.py
+++ b/dags/etl_import_ensembl.py
@@ -16,7 +16,7 @@ from lib.utils_s3 import get_s3_file_version, download_and_check_md5, load_to_s3
 with DAG(
     dag_id='etl_import_ensembl',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_fhir.py
+++ b/dags/etl_import_fhir.py
@@ -17,7 +17,7 @@ from lib.utils_etl import color, skip_if_param_not
 with DAG(
     dag_id='etl_import_fhir',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'fhir': Param('no', enum=['yes', 'no']),
         'csv': Param('no', enum=['yes', 'no']),

--- a/dags/etl_import_franklin.py
+++ b/dags/etl_import_franklin.py
@@ -15,7 +15,7 @@ with DAG(
         dag_id='etl_import_franklin',
         doc_md=doc.franklin,
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         render_template_as_native_obj=True,
         default_args={
             'trigger_rule': TriggerRule.NONE_FAILED,

--- a/dags/etl_import_genes.py
+++ b/dags/etl_import_genes.py
@@ -11,7 +11,7 @@ from lib.slack import Slack
 with DAG(
         dag_id='etl_import_genes',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         max_active_tasks=1,  # Only one task can be scheduled at a time
         default_args={
             'trigger_rule': TriggerRule.NONE_FAILED,

--- a/dags/etl_import_gnomad_constraint.py
+++ b/dags/etl_import_gnomad_constraint.py
@@ -16,7 +16,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
         dag_id='etl_import_gnomad_constraint',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         default_args={
             'on_failure_callback': Slack.notify_task_failure,
         }

--- a/dags/etl_import_gnomad_v4_cnv.py
+++ b/dags/etl_import_gnomad_v4_cnv.py
@@ -19,7 +19,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_gnomad_v4_cnv',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'spark_jar': Param('', type=['null', 'string']),
         },

--- a/dags/etl_import_gnomad_v4_joint.py
+++ b/dags/etl_import_gnomad_v4_joint.py
@@ -21,7 +21,7 @@ GNOMAD_S3_BUCKET = "gnomad-public-us-east-1"
 @dag(
     dag_id="etl_import_gnomad_v4_joint",
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     max_active_tasks=1,
     default_args={
         "on_failure_callback": Slack.notify_task_failure,

--- a/dags/etl_import_hpo.py
+++ b/dags/etl_import_hpo.py
@@ -26,7 +26,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_hpo',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'color': Param('', type=['null', 'string']),
         'spark_jar': Param('', type=['null', 'string']),
@@ -85,16 +85,14 @@ with DAG(
     download_hpo_genes = PythonOperator(
         task_id='download_hpo_genes',
         python_callable=download,
-        op_args=['genes_to_phenotype.txt'],
-        provide_context=True,
+        op_args=['genes_to_phenotype.txt']
     )
 
     # not used for now but we could maybe update obo-parser to use that file as input instead of downloading the obo file
     download_hpo_terms = PythonOperator(
         task_id='download_hpo_terms',
         python_callable=download,
-        op_args=['hp-fr.obo', 'hp.obo'],
-        provide_context=True,
+        op_args=['hp-fr.obo', 'hp.obo']
     )
 
     normalized_hpo_genes = SparkOperator(

--- a/dags/etl_import_human_genes.py
+++ b/dags/etl_import_human_genes.py
@@ -15,7 +15,7 @@ from lib.utils_s3 import get_s3_file_md5, download_and_check_md5, load_to_s3_wit
 with DAG(
     dag_id='etl_import_human_genes',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_mondo.py
+++ b/dags/etl_import_mondo.py
@@ -27,7 +27,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_mondo',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'color': Param('', type=['null', 'string']),
         'spark_jar': Param('', type=['null', 'string']),
@@ -87,8 +87,7 @@ with DAG(
     download_mondo_terms = PythonOperator(
         task_id='download_mondo_terms',
         python_callable=download,
-        op_args=['mondo-base.obo', 'mondo.obo'],
-        provide_context=True,
+        op_args=['mondo-base.obo', 'mondo.obo']
     )
 
     normalized_mondo_terms = SparkOperator(

--- a/dags/etl_import_omim.py
+++ b/dags/etl_import_omim.py
@@ -10,7 +10,7 @@ from lib.slack import Slack
 with DAG(
     dag_id='etl_import_omim',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_orphanet.py
+++ b/dags/etl_import_orphanet.py
@@ -15,7 +15,7 @@ from lib.utils_s3 import get_s3_file_md5, download_and_check_md5, load_to_s3_wit
 with DAG(
     dag_id='etl_import_orphanet',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_panels.py
+++ b/dags/etl_import_panels.py
@@ -18,7 +18,7 @@ from lib.utils_etl import color, spark_jar
 with DAG(
     dag_id='etl_import_panels',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
         params={
         'panels': Param('', type='string'),
         'color': Param('', type=['null', 'string']),

--- a/dags/etl_import_rare_variant.py
+++ b/dags/etl_import_rare_variant.py
@@ -11,7 +11,7 @@ from lib.slack import Slack
 with DAG(
         dag_id='etl_import_rare_variant',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         max_active_tasks=1,  # Only one task can be scheduled at a time
         default_args={
             'trigger_rule': TriggerRule.NONE_FAILED,

--- a/dags/etl_import_refseq_annotation.py
+++ b/dags/etl_import_refseq_annotation.py
@@ -17,7 +17,7 @@ from lib.utils_s3 import get_s3_file_version, load_to_s3_with_version
 with DAG(
     dag_id='etl_import_refseq_annotation',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_spliceai.py
+++ b/dags/etl_import_spliceai.py
@@ -18,7 +18,7 @@ from lib.utils_s3 import stream_upload_to_s3, get_s3_file_version
 with DAG(
         dag_id='etl_import_spliceai',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         max_active_tasks=1,  # Only one task can be scheduled at a time
         default_args={
             'on_failure_callback': Slack.notify_task_failure,

--- a/dags/etl_import_topmed_bravo.py
+++ b/dags/etl_import_topmed_bravo.py
@@ -19,7 +19,7 @@ from lib.utils_s3 import get_s3_file_version
 with DAG(
     dag_id='etl_import_topmed_bravo',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,
     },

--- a/dags/etl_import_varsome.py
+++ b/dags/etl_import_varsome.py
@@ -13,7 +13,7 @@ if env in [Env.PROD]:
     with DAG(
         dag_id='etl_import_varsome',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'batch_id':  Param('', type='string'),
         },

--- a/dags/etl_ingest.py
+++ b/dags/etl_ingest.py
@@ -17,7 +17,7 @@ from lib.utils_etl import batch_id, color, skip_import, spark_jar
 with DAG(
         dag_id='etl_ingest',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'batch_id': Param('', type='string'),
             'color': Param('', type=['null', 'string']),

--- a/dags/etl_migrate.py
+++ b/dags/etl_migrate.py
@@ -20,7 +20,7 @@ from lib.utils_etl import color, get_group_id, spark_jar
 with DAG(
         dag_id='etl_migrate',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'color': Param('', type=['null', 'string']),
             'snv': Param('no', enum=['yes', 'no']),

--- a/dags/etl_notify.py
+++ b/dags/etl_notify.py
@@ -11,7 +11,7 @@ from lib.utils_etl import batch_id, color
 with DAG(
         dag_id='etl_notify',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'batch_id': Param('', type='string'),
             'color': Param('', type=['null', 'string']),

--- a/dags/etl_qa.py
+++ b/dags/etl_qa.py
@@ -13,7 +13,7 @@ with DAG(
     dag_id='etl_qa',
     doc_md=doc.etl_qa,
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'spark_jar': Param('', type=['null', 'string']),
     },

--- a/dags/etl_qc.py
+++ b/dags/etl_qc.py
@@ -14,7 +14,7 @@ with DAG(
     dag_id='etl_qc',
     doc_md=doc.etl_qc,
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'spark_jar': Param('', type=['null', 'string']),
     },

--- a/dags/etl_qc_es.py
+++ b/dags/etl_qc_es.py
@@ -9,7 +9,7 @@ from lib.slack import Slack
 with DAG(
     dag_id='etl_qc_es',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
     default_args={
         'on_failure_callback': Slack.notify_task_failure,

--- a/dags/etl_reset_enrich_cnv.py
+++ b/dags/etl_reset_enrich_cnv.py
@@ -8,7 +8,7 @@ from lib.tasks import enrich
 with DAG(
         dag_id='etl_reset_enrich_cnv',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         default_args={
             'on_failure_callback': Slack.notify_task_failure,
         },

--- a/dags/etl_reset_enrich_consequences.py
+++ b/dags/etl_reset_enrich_consequences.py
@@ -8,7 +8,7 @@ from lib.tasks import enrich
 with DAG(
         dag_id='etl_reset_enrich_consequences',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         default_args={
             'on_failure_callback': Slack.notify_task_failure,
         },

--- a/dags/etl_reset_enrich_variants.py
+++ b/dags/etl_reset_enrich_variants.py
@@ -7,7 +7,7 @@ from lib.tasks import enrich
 with DAG(
         dag_id='etl_reset_enrich_variants',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         default_args={
             'on_failure_callback': Slack.notify_task_failure,
         },

--- a/dags/etl_rolling.py
+++ b/dags/etl_rolling.py
@@ -17,7 +17,7 @@ if env == Env.QA:
     with DAG(
             dag_id='etl_rolling',
             start_date=datetime(2022, 1, 1),
-            schedule_interval=None,
+            schedule=None,
             doc_md=doc.rolling,
             params={
                 'release_id': Param('', type=['null', 'string']),

--- a/dags/etl_rolling_auto.py
+++ b/dags/etl_rolling_auto.py
@@ -12,7 +12,7 @@ if env == Env.QA:
     with DAG(
             dag_id='etl_rolling_auto',
             start_date=datetime(2022, 1, 1),
-            schedule_interval="0 6 * * *" if env == Env.QA else None, # 6am UTC / 2am Montreal
+            schedule="0 6 * * *" if env == Env.QA else None, # 6am UTC / 2am Montreal
             catchup=False,
             params={
 

--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -21,7 +21,7 @@ from pandas import DataFrame
 with DAG(
         dag_id='etl_run',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         catchup=False,
         params={
             'sequencing_ids': Param([], type=['null', 'array']),

--- a/dags/lib/config_operators.py
+++ b/dags/lib/config_operators.py
@@ -16,7 +16,7 @@ kube_config_etl = KubeConfig(
 # This is meant to be used in DAGS depending on the NextflowOperator.
 nextflow_base_config = NextflowOperatorConfig(
     kube_config=kube_config_etl,
-    is_delete_operator_pod=True,
+    on_finish_action='delete_pod',
     image='nextflow/nextflow:23.10.1',
     service_account_name='nextflow',
     minio_credentials_secret_name=f'cqgc-{env}-minio-app-nextflow',

--- a/dags/lib/operators/arranger.py
+++ b/dags/lib/operators/arranger.py
@@ -1,7 +1,7 @@
-from airflow.exceptions import AirflowFailException, AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.exceptions import AirflowSkipException
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 
 
@@ -18,7 +18,7 @@ class ArrangerOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/aws.py
+++ b/dags/lib/operators/aws.py
@@ -1,5 +1,6 @@
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 
 
@@ -11,7 +12,7 @@ class AwsOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/base_kubernetes.py
+++ b/dags/lib/operators/base_kubernetes.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field, fields, asdict
 from typing import Optional, List, Type, TypeVar
 from typing_extensions import Self
 
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.utils.context import Context
 from kubernetes.client import models as k8s
 
@@ -97,12 +97,12 @@ class BaseConfig:
     """
     BaseConfig is a dataclass that contains the configuration for a BaseKubernetesOperator
     :param kube_config: KubeConfig
-    :param is_delete_operator_pod: bool
+    :param on_finish_action: str
     :param image: Optional[str]
     :param service_account_name: Optional[str] - @see KubernetesPodOperator.service_account_name
     """
     kube_config: KubeConfig
-    is_delete_operator_pod: bool = False
+    on_finish_action: str = 'keep_pod'
     image: Optional[str] = None
     arguments: List[str] = field(default_factory=list)
     service_account_name: Optional[str] = None

--- a/dags/lib/operators/curl.py
+++ b/dags/lib/operators/curl.py
@@ -1,9 +1,7 @@
 from typing import List
 
-from airflow import AirflowException
-from airflow.exceptions import AirflowFailException, AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
 from lib import config
 from lib.config import env
@@ -23,7 +21,7 @@ class CurlOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/fhir.py
+++ b/dags/lib/operators/fhir.py
@@ -1,7 +1,7 @@
 from airflow.exceptions import AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 from lib.config import auth_url, env_url
 from lib.utils import join
@@ -21,7 +21,7 @@ class FhirOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/fhir_csv.py
+++ b/dags/lib/operators/fhir_csv.py
@@ -1,7 +1,7 @@
 from airflow.exceptions import AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 from lib.config import auth_url, env_url
 from lib.utils import join
@@ -21,7 +21,7 @@ class FhirCsvOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/panels.py
+++ b/dags/lib/operators/panels.py
@@ -1,5 +1,5 @@
 from airflow.exceptions import AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
 from lib import config
 from lib.config import env, env_url
@@ -19,7 +19,7 @@ class PanelsOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/pipeline.py
+++ b/dags/lib/operators/pipeline.py
@@ -1,7 +1,7 @@
 from airflow.exceptions import AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 from lib.config import auth_url, env, env_url
 from lib.utils import join
@@ -24,7 +24,7 @@ class PipelineOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/postgres.py
+++ b/dags/lib/operators/postgres.py
@@ -1,4 +1,4 @@
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
 from lib import config
 from lib.config import env
@@ -18,7 +18,7 @@ class PostgresOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/spark.py
+++ b/dags/lib/operators/spark.py
@@ -3,9 +3,9 @@ from typing import List
 
 import kubernetes
 from airflow.exceptions import AirflowFailException, AirflowSkipException
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import \
-    KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
+
 from lib import config
 from lib.config import env
 
@@ -34,7 +34,7 @@ class SparkOperator(KubernetesPodOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            is_delete_operator_pod=False,
+            on_finish_action='keep_pod',
             in_cluster=config.k8s_in_cluster(k8s_context),
             config_file=config.k8s_config_file(k8s_context),
             cluster_context=config.k8s_cluster_context(k8s_context),

--- a/dags/lib/operators/utils/utils_pod.py
+++ b/dags/lib/operators/utils/utils_pod.py
@@ -1,4 +1,4 @@
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from kubernetes.client import models as k8s
 

--- a/dags/script_etl.py
+++ b/dags/script_etl.py
@@ -18,7 +18,7 @@ with DAG(
     dag_id='script_etl',
     start_date=datetime(2022, 1, 1),
     catchup=False,
-    schedule_interval=None,
+    schedule=None,
     description="Run an ad-hoc Spark script.",
     params={
         'spark_class': Param(SCRIPT_MAIN_CLASS, type='string'),

--- a/dags/script_pipeline.py
+++ b/dags/script_pipeline.py
@@ -12,7 +12,7 @@ from lib.utils_etl import color
 with DAG(
     dag_id='script_pipeline',
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     params={
         'script': Param('', type='string'),
         'args': Param('', type=['null', 'string']),

--- a/dags/test_kube_client_default.py
+++ b/dags/test_kube_client_default.py
@@ -12,7 +12,7 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_kube_client_default',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
     ) as dag:
 
         def _test_kube_client_default():

--- a/dags/test_kube_client_etl.py
+++ b/dags/test_kube_client_etl.py
@@ -12,7 +12,7 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_kube_client_etl',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
     ) as dag:
 
         def _test_kube_client_etl():

--- a/dags/test_pod_operator_default.py
+++ b/dags/test_pod_operator_default.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from datetime import datetime
 from lib import config
 from lib.config import K8sContext
@@ -10,13 +10,13 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_pod_operator_default',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
     ) as dag:
 
         test_pod_operator_default = KubernetesPodOperator(
             task_id='test_pod_operator_default',
             name='test-pod-operator-default',
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(K8sContext.DEFAULT),
             config_file=config.k8s_config_file(K8sContext.DEFAULT),
             cluster_context=config.k8s_cluster_context(K8sContext.DEFAULT),

--- a/dags/test_pod_operator_etl.py
+++ b/dags/test_pod_operator_etl.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from datetime import datetime
 from lib import config
 from lib.config import K8sContext
@@ -10,13 +10,13 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_pod_operator_etl',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
     ) as dag:
 
         test_pod_operator_etl = KubernetesPodOperator(
             task_id='test_pod_operator_etl',
             name='test-pod-operator-etl',
-            is_delete_operator_pod=True,
+            on_finish_action='delete_pod',
             in_cluster=config.k8s_in_cluster(K8sContext.ETL),
             config_file=config.k8s_config_file(K8sContext.ETL),
             cluster_context=config.k8s_cluster_context(K8sContext.ETL),

--- a/dags/test_slack.py
+++ b/dags/test_slack.py
@@ -10,7 +10,7 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_slack',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
     ) as dag:
 
         test_slack = SlackOperator(

--- a/dags/test_spark_fail.py
+++ b/dags/test_spark_fail.py
@@ -11,7 +11,7 @@ if (config.show_test_dags):
     with DAG(
         dag_id='test_spark_fail',
         start_date=datetime(2022, 1, 1),
-        schedule_interval=None,
+        schedule=None,
         params={
             'spark_jar': Param('', type=['null', 'string']),
         },

--- a/requirements
+++ b/requirements
@@ -1,6 +1,0 @@
-apache-airflow
-apache-airflow-providers-amazon
-apache-airflow-providers-cncf-kubernetes
-kubernetes
-deltalake===0.24.0
-phenopackets===2.0.2.post4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+apache-airflow==2.9.3
+apache-airflow-providers-amazon==8.25.0
+apache-airflow-providers-cncf-kubernetes==8.3.3
+kubernetes~=29.0.0
+pandas~=2.1.4
+deltalake==0.24.0
+phenopackets==2.0.2.post4
+pytest
+virtualenv~=20.26.3


### PR DESCRIPTION
Changes
--
* [build: Align requirements with airflow image](https://github.com/Ferlab-Ste-Justine/clin-pipelines-dags/commit/4a628bcb43fed9a420ad424cbfc0973e38604dd9)
* [fix: Use .venv as default folder to align with standard](https://github.com/Ferlab-Ste-Justine/clin-pipelines-dags/commit/5062bb191363ada23970d96d48b50360c172c6d5)
* [fix: Update deprecated code](https://github.com/Ferlab-Ste-Justine/clin-pipelines-dags/commit/f8cb1952565a048749fb7af643debe03b4de4fa6)
  * Rename `schedule_interval` to `schedule`
  * Remove `provide_context` (True by default)
  * Import `KubernetesPodOperator` from correct module
  * Use `on_finish_action` instead of `is_delete_operator_pod`

Tests
--
DagBag builds properly in local setup:

<img width="1418" alt="Screenshot 2025-05-30 at 5 34 30 PM" src="https://github.com/user-attachments/assets/cfe9e1f9-e34d-49f4-b445-f143cda1f5e6" />

