### PR TITLE
feat: CLIN-4328 - batch ids and sequencing ids Part 1

### DIFF
--- a/dags/etl.py
+++ b/dags/etl.py
@@ -31,7 +31,7 @@ with DAG(
             'batch_ids': Param([], type=['null', 'array'],
                                description='Put a single batch id per line. Leave empty to skip ingest.'),
             'sequencing_ids': Param([], type=['null', 'array'],
-                               description='Put a single id id per line. Leave empty to skip ingest.'),
+                               description='Put a single id per line. Leave empty to skip ingest.'),
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),
             'import': Param('yes', enum=['yes', 'no']),

--- a/dags/etl_ingest.py
+++ b/dags/etl_ingest.py
@@ -45,7 +45,7 @@ with DAG(
 
     get_sequencing_ids_task = get_sequencing_ids()
 
-    detect_batch_type_task = batch_type.detect(batch_ids=batch_id(), sequencing_ids=get_sequencing_ids_task)
+    detect_batch_type_task = batch_type.detect(batch_id=batch_id(), sequencing_ids=get_sequencing_ids_task)
 
     ingest_germline_group = ingest_germline(
         batch_id=batch_id(),

--- a/dags/etl_ingest.py
+++ b/dags/etl_ingest.py
@@ -49,6 +49,7 @@ with DAG(
 
     ingest_germline_group = ingest_germline(
         batch_id=batch_id(),
+        sequencing_ids=get_sequencing_ids_task,
         batch_type_detected=True,
         color=color(),
         skip_import=skip_import(),  # skipping already imported batch is allowed
@@ -66,6 +67,7 @@ with DAG(
 
     ingest_somatic_tumor_only_group = ingest_somatic_tumor_only(
         batch_id=batch_id(),
+        sequencing_ids=get_sequencing_ids_task,
         batch_type_detected=True,
         color=color(),
         skip_import=skip_import(),  # skipping already imported batch is allowed
@@ -80,6 +82,7 @@ with DAG(
 
     ingest_somatic_tumor_normal_group = ingest_somatic_tumor_normal(
         batch_id=batch_id(),
+        sequencing_ids=get_sequencing_ids_task,
         batch_type_detected=True,
         color=color(),
         skip_import=skip_import(),  # skipping already imported batch is allowed

--- a/dags/etl_migrate.py
+++ b/dags/etl_migrate.py
@@ -103,7 +103,7 @@ with DAG(
 
     def migrate_batch_id(batch_id: str) -> TaskGroup:
         with TaskGroup(group_id=get_group_id('migrate', batch_id)) as group:
-            detect_batch_type_task = batch_type.detect(batch_id)
+            detect_batch_type_task = batch_type.detect(batch_ids=batch_id)
 
             migrate_germline_group = migrate_germline(
                 batch_id=batch_id,

--- a/dags/etl_notify.py
+++ b/dags/etl_notify.py
@@ -5,7 +5,7 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from lib.slack import Slack
 from lib.tasks.notify import notify
-from lib.tasks.params_validate import validate_batch_sequencing_ids_color
+from lib.tasks.params_validate import validate_batch_analysis_ids_color
 from lib.utils_etl import batch_id, color
 
 with DAG(
@@ -20,7 +20,7 @@ with DAG(
             'on_failure_callback': Slack.notify_task_failure,
         },
 ) as dag:
-    params_validate = validate_batch_sequencing_ids_color(batch_id(), None, color())
+    params_validate = validate_batch_analysis_ids_color(batch_id(), None, color())
 
     notify_task = notify(
         batch_id=batch_id(),

--- a/dags/etl_notify.py
+++ b/dags/etl_notify.py
@@ -5,7 +5,7 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from lib.slack import Slack
 from lib.tasks.notify import notify
-from lib.tasks.params_validate import validate_batch_color
+from lib.tasks.params_validate import validate_batch_sequencing_ids_color
 from lib.utils_etl import batch_id, color
 
 with DAG(
@@ -20,7 +20,7 @@ with DAG(
             'on_failure_callback': Slack.notify_task_failure,
         },
 ) as dag:
-    params_validate = validate_batch_color(batch_id(), color())
+    params_validate = validate_batch_sequencing_ids_color(batch_id(), None, color())
 
     notify_task = notify(
         batch_id=batch_id(),

--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -127,7 +127,7 @@ with DAG(
         return urlsafe_hash(all_analysis_ids, length=14)  # 14 is safe for up to 1B hashes
     
     @task
-    def prepare_exomiser_references_analysis_ids(all_analysis_ids: Set[str]) -> List[str]:
+    def prepare_exomiser_references_analysis_ids(all_analysis_ids: Set[str]) -> str:
         return '--analysis-ids=' + ','.join(all_analysis_ids)
 
     get_all_sequencing_ids_task = get_all_sequencing_ids(get_sequencing_ids())

--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -18,7 +18,7 @@ from lib.tasks import batch_type
 from lib.tasks.nextflow import exomiser, post_processing
 from lib.tasks.params_validate import validate_color
 from lib.utils_etl import (ClinAnalysis, color,
-                           get_ingest_dag_configs_by_sequencing_ids, spark_jar)
+                           get_ingest_dag_configs_by_analysis_ids, spark_jar)
 from pandas import DataFrame
 
 with DAG(
@@ -59,7 +59,7 @@ with DAG(
         spark_jar=spark_jar()
     )
 
-    @task.virtualenv(task_id='get_all_sequencing_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+    @task.virtualenv(task_id='get_all_sequencing_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
     def get_all_sequencing_ids(sequencing_ids: List[str]) -> Set[str]:
         """
         Retrieves all sequencing IDs that share the same analysis ID as the given sequencing IDs from the
@@ -104,7 +104,7 @@ with DAG(
 
         return _all_sequencing_ids
 
-    @task.virtualenv(task_id='get_all_analysis_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+    @task.virtualenv(task_id='get_all_analysis_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
     def get_all_analysis_ids(all_sequencing_ids: Set[str]) -> str:
         """
         Retrieves all analysis IDs for every sequencing IDs
@@ -117,7 +117,7 @@ with DAG(
 
         return sorted(get_analysis_ids(clinical_df, all_sequencing_ids))
 
-    @task.virtualenv(task_id='get_job_hash', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+    @task.virtualenv(task_id='get_job_hash', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
     def get_job_hash(all_analysis_ids: Set[str]) -> str:
         """
         Generate a unique hash for the job using the analysis IDs associated to the input sequencing IDs. The hash is used to name the input samplesheet file and the output directory in the nextflow post-processing pipeline.
@@ -143,6 +143,8 @@ with DAG(
         input=prepare_nextflow_post_processing_task,
         job_hash=get_job_hash_task
     )
+
+    prepare_exomiser_references_analysis_ids_task = prepare_exomiser_references_analysis_ids(get_all_analysis_ids_task)
     
     add_exomiser_references_task = PipelineOperator(
         task_id='add_exomiser_references_task',
@@ -152,21 +154,21 @@ with DAG(
         max_active_tis_per_dag=10,
         arguments=[
             'bio.ferlab.clin.etl.AddNextflowDocuments',
-            prepare_exomiser_references_analysis_ids(get_all_analysis_ids_task),
+            prepare_exomiser_references_analysis_ids_task,
             '--nextflow-output-folder=' + f'{nextflow_bucket}/{nextflow_post_processing_exomiser_output_key}',
             '--exomiser-type=snv',
         ]
     )
     
-    detect_batch_types_task = batch_type.detect(sequencing_ids=get_all_sequencing_ids_task, allowMultipleIdentifierTypes=True)
+    detect_batch_types_task = batch_type.detect(analysis_ids=get_all_analysis_ids_task, allowMultipleIdentifierTypes=True)
 
-    get_ingest_dag_configs_by_sequencing_ids_task = get_ingest_dag_configs_by_sequencing_ids.partial(all_batch_types=detect_batch_types_task, sequencing_ids=get_all_sequencing_ids_task).expand(analysisType=[ClinAnalysis.GERMLINE.value, ClinAnalysis.SOMATIC_TUMOR_ONLY.value])
+    get_ingest_dag_configs_by_analysis_ids_task = get_ingest_dag_configs_by_analysis_ids.partial(all_batch_types=detect_batch_types_task, analysis_ids=get_all_sequencing_ids_task).expand(analysisType=[ClinAnalysis.GERMLINE.value, ClinAnalysis.SOMATIC_TUMOR_ONLY.value])
 
     trigger_ingest_by_sequencing_ids_dags = TriggerDagRunOperator.partial(
         task_id='ingest_sequencing_ids',
         trigger_dag_id='etl_ingest',
         wait_for_completion=True,
-    ).expand(conf=get_ingest_dag_configs_by_sequencing_ids_task)
+    ).expand(conf=get_ingest_dag_configs_by_analysis_ids_task)
 
     slack = EmptyOperator(
         task_id="slack",
@@ -176,9 +178,9 @@ with DAG(
     (
         start >> params_validate >>
         ingest_fhir_group >>
-        get_all_sequencing_ids_task >> get_job_hash_task >>
-        [prepare_nextflow_exomiser_task, prepare_nextflow_post_processing_task] >>
-        nextflow_post_processing_task >> add_exomiser_references_task >>
-        detect_batch_types_task >> get_ingest_dag_configs_by_sequencing_ids_task >> trigger_ingest_by_sequencing_ids_dags >>
+        get_all_sequencing_ids_task >> get_all_analysis_ids_task >> get_job_hash_task >>
+        prepare_nextflow_exomiser_task, prepare_nextflow_post_processing_task >>
+        nextflow_post_processing_task >> prepare_exomiser_references_analysis_ids_task >> add_exomiser_references_task >>
+        detect_batch_types_task >> get_ingest_dag_configs_by_analysis_ids_task >> trigger_ingest_by_sequencing_ids_dags >>
         slack
     )

--- a/dags/lib/groups/ingest/ingest_germline.py
+++ b/dags/lib/groups/ingest/ingest_germline.py
@@ -1,14 +1,14 @@
-from airflow.decorators import task_group, task
-
+from airflow.decorators import task, task_group
 from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.groups.normalize.normalize_germline import normalize_germline
-from lib.tasks import (batch_type)
+from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis
 
 
 @task_group(group_id='ingest_germline')
 def ingest_germline(
         batch_id: str,
+        sequencing_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -27,6 +27,7 @@ def ingest_germline(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         batch_type=ClinAnalysis.GERMLINE,
         skip=skip_all
     )
@@ -42,6 +43,7 @@ def ingest_germline(
 
     normalize_germline_group = normalize_germline(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         skip_all=skip_all,
         skip_snv=skip_snv,
         skip_cnv=skip_cnv,

--- a/dags/lib/groups/ingest/ingest_germline.py
+++ b/dags/lib/groups/ingest/ingest_germline.py
@@ -8,7 +8,7 @@ from lib.utils_etl import ClinAnalysis
 @task_group(group_id='ingest_germline')
 def ingest_germline(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -27,7 +27,7 @@ def ingest_germline(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         batch_type=ClinAnalysis.GERMLINE,
         skip=skip_all
     )
@@ -43,7 +43,7 @@ def ingest_germline(
 
     normalize_germline_group = normalize_germline(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         skip_all=skip_all,
         skip_snv=skip_snv,
         skip_cnv=skip_cnv,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
@@ -1,14 +1,15 @@
 from airflow.decorators import task_group
-
 from lib.groups.ingest.ingest_fhir import ingest_fhir
-from lib.groups.normalize.normalize_somatic_tumor_normal import normalize_somatic_tumor_normal
-from lib.tasks import (batch_type)
+from lib.groups.normalize.normalize_somatic_tumor_normal import \
+    normalize_somatic_tumor_normal
+from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis
 
 
 @task_group(group_id='ingest_somatic_tumor_normal')
 def ingest_somatic_tumor_normal(
         batch_id: str,
+        sequencing_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -23,6 +24,7 @@ def ingest_somatic_tumor_normal(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         batch_type=ClinAnalysis.SOMATIC_TUMOR_NORMAL,
         skip=skip_all
     )
@@ -39,6 +41,7 @@ def ingest_somatic_tumor_normal(
 
     normalize_somatic_tumor_normal_group = normalize_somatic_tumor_normal(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_variants=skip_variants,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
@@ -9,7 +9,7 @@ from lib.utils_etl import ClinAnalysis
 @task_group(group_id='ingest_somatic_tumor_normal')
 def ingest_somatic_tumor_normal(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -24,7 +24,7 @@ def ingest_somatic_tumor_normal(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         batch_type=ClinAnalysis.SOMATIC_TUMOR_NORMAL,
         skip=skip_all
     )
@@ -41,7 +41,7 @@ def ingest_somatic_tumor_normal(
 
     normalize_somatic_tumor_normal_group = normalize_somatic_tumor_normal(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_variants=skip_variants,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
@@ -1,14 +1,15 @@
 from airflow.decorators import task_group
-
 from lib.groups.ingest.ingest_fhir import ingest_fhir
-from lib.groups.normalize.normalize_somatic_tumor_only import normalize_somatic_tumor_only
-from lib.tasks import (batch_type)
+from lib.groups.normalize.normalize_somatic_tumor_only import \
+    normalize_somatic_tumor_only
+from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis
 
 
 @task_group(group_id='ingest_somatic_tumor_only')
 def ingest_somatic_tumor_only(
         batch_id: str,
+        sequencing_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -24,6 +25,7 @@ def ingest_somatic_tumor_only(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         batch_type=ClinAnalysis.SOMATIC_TUMOR_ONLY,
         skip=skip_all
     )
@@ -39,6 +41,7 @@ def ingest_somatic_tumor_only(
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
@@ -9,7 +9,7 @@ from lib.utils_etl import ClinAnalysis
 @task_group(group_id='ingest_somatic_tumor_only')
 def ingest_somatic_tumor_only(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         batch_type_detected: bool,
         color: str,
         skip_import: str,
@@ -25,7 +25,7 @@ def ingest_somatic_tumor_only(
 
     validate_batch_type_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         batch_type=ClinAnalysis.SOMATIC_TUMOR_ONLY,
         skip=skip_all
     )
@@ -41,7 +41,7 @@ def ingest_somatic_tumor_only(
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only,

--- a/dags/lib/groups/migrate/migrate_germline.py
+++ b/dags/lib/groups/migrate/migrate_germline.py
@@ -1,5 +1,4 @@
 from airflow.decorators import task_group
-
 from lib.groups.normalize.normalize_germline import normalize_germline
 from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis, get_group_id
@@ -27,12 +26,14 @@ def migrate_germline(
 
     validate_germline_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=[],
         batch_type=ClinAnalysis.GERMLINE,
         skip=skip_all
     )
 
     normalize_germline_group = normalize_germline(
         batch_id=batch_id,
+        sequencing_ids=[],
         skip_all=skip_all,
         skip_snv=skip_snv,
         skip_cnv=skip_cnv,

--- a/dags/lib/groups/migrate/migrate_germline.py
+++ b/dags/lib/groups/migrate/migrate_germline.py
@@ -26,14 +26,14 @@ def migrate_germline(
 
     validate_germline_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         batch_type=ClinAnalysis.GERMLINE,
         skip=skip_all
     )
 
     normalize_germline_group = normalize_germline(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         skip_all=skip_all,
         skip_snv=skip_snv,
         skip_cnv=skip_cnv,

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
@@ -1,6 +1,6 @@
 from airflow.decorators import task_group
-
-from lib.groups.normalize.normalize_somatic_tumor_normal import normalize_somatic_tumor_normal
+from lib.groups.normalize.normalize_somatic_tumor_normal import \
+    normalize_somatic_tumor_normal
 from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis, get_group_id
 
@@ -23,12 +23,14 @@ def migrate_somatic_tumor_normal(
 
     validate_somatic_tumor_normal_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=[],
         batch_type=ClinAnalysis.SOMATIC_TUMOR_NORMAL,
         skip=skip_all
     )
 
     normalize_somatic_tumor_normal_group = normalize_somatic_tumor_normal(
         batch_id=batch_id,
+        sequencing_ids=[],
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_variants=skip_variants,

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
@@ -23,14 +23,14 @@ def migrate_somatic_tumor_normal(
 
     validate_somatic_tumor_normal_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         batch_type=ClinAnalysis.SOMATIC_TUMOR_NORMAL,
         skip=skip_all
     )
 
     normalize_somatic_tumor_normal_group = normalize_somatic_tumor_normal(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_variants=skip_variants,

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
@@ -1,6 +1,6 @@
 from airflow.decorators import task_group
-
-from lib.groups.normalize.normalize_somatic_tumor_only import normalize_somatic_tumor_only
+from lib.groups.normalize.normalize_somatic_tumor_only import \
+    normalize_somatic_tumor_only
 from lib.tasks import batch_type
 from lib.utils_etl import ClinAnalysis, get_group_id
 
@@ -24,12 +24,14 @@ def migrate_somatic_tumor_only(
 
     validate_somatic_tumor_only_task = batch_type.validate(
         batch_id=batch_id,
+        sequencing_ids=[],
         batch_type=ClinAnalysis.SOMATIC_TUMOR_ONLY,
         skip=skip_all
     )
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
         batch_id=batch_id,
+        sequencing_ids=[],
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only,

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
@@ -24,14 +24,14 @@ def migrate_somatic_tumor_only(
 
     validate_somatic_tumor_only_task = batch_type.validate(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         batch_type=ClinAnalysis.SOMATIC_TUMOR_ONLY,
         skip=skip_all
     )
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
         batch_id=batch_id,
-        sequencing_ids=[],
+        analysis_ids=[],
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,
         skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only,

--- a/dags/lib/groups/normalize/normalize_germline.py
+++ b/dags/lib/groups/normalize/normalize_germline.py
@@ -1,16 +1,17 @@
 from airflow.decorators import task_group
-
 from lib import utils_nextflow
-from lib.config_nextflow import nextflow_svclustering_parental_origin_input_key, nextflow_bucket
+from lib.config_nextflow import (
+    nextflow_bucket, nextflow_svclustering_parental_origin_input_key)
 from lib.groups.franklin.franklin_update import FranklinUpdate
 from lib.tasks import normalize
 from lib.tasks.nextflow import svclustering_parental_origin
-from lib.utils_etl import skip
+from lib.utils_etl import ClinAnalysis, skip
 
 
 @task_group(group_id='normalize')
 def normalize_germline(
         batch_id: str,
+        sequencing_ids: list,
         skip_all: str,
         skip_snv: str,
         skip_cnv: str,
@@ -22,12 +23,15 @@ def normalize_germline(
         skip_nextflow: str,
         spark_jar: str,
 ):
-    snv = normalize.snv(batch_id, spark_jar, skip(skip_all, skip_snv))
-    cnv = normalize.cnv(batch_id, spark_jar, skip(skip_all, skip_cnv))
-    variants = normalize.variants(batch_id, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, spark_jar, skip(skip_all, skip_consequences))
-    exomiser = normalize.exomiser(batch_id, spark_jar, skip(skip_all, skip_exomiser))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    
+    target_batch_types = [ClinAnalysis.GERMLINE]
+
+    snv = normalize.snv(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv))
+    cnv = normalize.cnv(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv))
+    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    exomiser = normalize.exomiser(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     franklin_update = FranklinUpdate(
         group_id='franklin_update',
@@ -37,7 +41,7 @@ def normalize_germline(
         timeout=0,
     )
 
-    franklin = normalize.franklin(batch_id, spark_jar, skip(skip_all, skip_franklin))
+    franklin = normalize.franklin(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_franklin))
 
     @task_group(group_id="nextflow")
     def nextflow_group():

--- a/dags/lib/groups/normalize/normalize_germline.py
+++ b/dags/lib/groups/normalize/normalize_germline.py
@@ -11,7 +11,7 @@ from lib.utils_etl import ClinAnalysis, skip
 @task_group(group_id='normalize')
 def normalize_germline(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         skip_all: str,
         skip_snv: str,
         skip_cnv: str,
@@ -26,12 +26,12 @@ def normalize_germline(
     
     target_batch_types = [ClinAnalysis.GERMLINE]
 
-    snv = normalize.snv(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv))
-    cnv = normalize.cnv(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv))
-    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    exomiser = normalize.exomiser(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv = normalize.snv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv))
+    cnv = normalize.cnv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv))
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    exomiser = normalize.exomiser(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     franklin_update = FranklinUpdate(
         group_id='franklin_update',
@@ -41,7 +41,7 @@ def normalize_germline(
         timeout=0,
     )
 
-    franklin = normalize.franklin(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_franklin))
+    franklin = normalize.franklin(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_franklin))
 
     @task_group(group_id="nextflow")
     def nextflow_group():

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
@@ -1,12 +1,12 @@
 from airflow.decorators import task_group
-
 from lib.tasks import normalize
-from lib.utils_etl import skip
+from lib.utils_etl import ClinAnalysis, skip
 
 
 @task_group(group_id='normalize')
 def normalize_somatic_tumor_normal(
         batch_id: str,
+        sequencing_ids: list,
         skip_all: str,
         skip_snv_somatic: str,
         skip_variants: str,
@@ -14,9 +14,12 @@ def normalize_somatic_tumor_normal(
         skip_coverage_by_gene: str,
         spark_jar: str,
 ):
-    snv_somatic = normalize.snv_somatic(batch_id, spark_jar, skip(skip_all, skip_snv_somatic))
-    variants = normalize.variants(batch_id, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    
+    target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_NORMAL]
+
+    snv_somatic = normalize.snv_somatic(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
+    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     snv_somatic >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
@@ -6,7 +6,7 @@ from lib.utils_etl import ClinAnalysis, skip
 @task_group(group_id='normalize')
 def normalize_somatic_tumor_normal(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         skip_all: str,
         skip_snv_somatic: str,
         skip_variants: str,
@@ -17,9 +17,9 @@ def normalize_somatic_tumor_normal(
     
     target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_NORMAL]
 
-    snv_somatic = normalize.snv_somatic(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
-    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     snv_somatic >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
@@ -6,7 +6,7 @@ from lib.utils_etl import ClinAnalysis, skip
 @task_group(group_id='normalize')
 def normalize_somatic_tumor_only(
         batch_id: str,
-        sequencing_ids: list,
+        analysis_ids: list,
         skip_all: str,
         skip_snv_somatic: str,
         skip_cnv_somatic_tumor_only: str,
@@ -17,10 +17,10 @@ def normalize_somatic_tumor_only(
 ):
     target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_ONLY]
 
-    snv_somatic = normalize.snv_somatic(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
-    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))
-    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
+    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     snv_somatic >> cnv_somatic_tumor_only >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
@@ -1,12 +1,12 @@
 from airflow.decorators import task_group
-
 from lib.tasks import normalize
-from lib.utils_etl import skip
+from lib.utils_etl import ClinAnalysis, skip
 
 
 @task_group(group_id='normalize')
 def normalize_somatic_tumor_only(
         batch_id: str,
+        sequencing_ids: list,
         skip_all: str,
         skip_snv_somatic: str,
         skip_cnv_somatic_tumor_only: str,
@@ -15,10 +15,12 @@ def normalize_somatic_tumor_only(
         skip_coverage_by_gene: str,
         spark_jar: str,
 ):
-    snv_somatic = normalize.snv_somatic(batch_id, spark_jar, skip(skip_all, skip_snv_somatic))
-    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))
-    variants = normalize.variants(batch_id, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    target_batch_types = [ClinAnalysis.GERMLINE]
+
+    snv_somatic = normalize.snv_somatic(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
+    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))
+    variants = normalize.variants(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
+    consequences = normalize.consequences(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
 
     snv_somatic >> cnv_somatic_tumor_only >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
@@ -15,7 +15,7 @@ def normalize_somatic_tumor_only(
         skip_coverage_by_gene: str,
         spark_jar: str,
 ):
-    target_batch_types = [ClinAnalysis.GERMLINE]
+    target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_ONLY]
 
     snv_somatic = normalize.snv_somatic(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
     cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, sequencing_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))

--- a/dags/lib/operators/spark_etl.py
+++ b/dags/lib/operators/spark_etl.py
@@ -30,7 +30,7 @@ class SparkETLOperator(SparkOperator):
          **kwargs: Additional arguments for `SparkOperator`.
      """
 
-    template_fields = SparkOperator.template_fields + ('batch_id', 'sequencing_ids',)
+    template_fields = SparkOperator.template_fields + ('batch_id', 'analysis_ids',)
 
     def __init__(self,
                  steps: str,
@@ -39,7 +39,7 @@ class SparkETLOperator(SparkOperator):
                  spark_config: str,
                  entrypoint: str = '',
                  batch_id: str = '',
-                 sequencing_ids: str = '',
+                 analysis_ids: str = '',
                  chromosome: str = '',
                  target_batch_types: List[ClinAnalysis] = None,
                  detect_batch_type_task_id: str = 'detect_batch_type',
@@ -59,7 +59,7 @@ class SparkETLOperator(SparkOperator):
         self.app_name = app_name
         self.entrypoint = entrypoint
         self.batch_id = batch_id
-        self.sequencing_ids = sequencing_ids
+        self.analysis_ids = analysis_ids
         self.chromosome = chromosome
         self.target_batch_types = [target.value for target in (target_batch_types or [])]
         self.detect_batch_type_task_id = detect_batch_type_task_id
@@ -68,14 +68,14 @@ class SparkETLOperator(SparkOperator):
         # Check if batch type is in target batch types if batch_id and target_batch_types is defined
         # Useful for dynamically mapped task for that should only be run for specific batch types
         if self.target_batch_types:
-            detect_batch_type_key = self.batch_id if self.batch_id else self.sequencing_ids[0] if self.sequencing_ids and len(self.sequencing_ids) > 0 else None
+            detect_batch_type_key = self.batch_id if self.batch_id else self.analysis_ids[0] if self.analysis_ids and len(self.analysis_ids) > 0 else None
             
             if not detect_batch_type_key:
-                raise AirflowFailException(f'No batch_id or sequencing_ids defined for task')
+                raise AirflowFailException(f'No batch_id or analysis_ids defined for task')
             
             batch_type = context['ti'].xcom_pull(task_ids=self.detect_batch_type_task_id, key=detect_batch_type_key)
                      
-            target_batch_type_message = f'Batch id \'{self.batch_id}\' | Sequencings ids \'{self.sequencing_ids}\' of batch type \'{batch_type}\' expected to be in ' \
+            target_batch_type_message = f'Batch id \'{self.batch_id}\' | Analysis ids \'{self.analysis_ids}\' of batch type \'{batch_type}\' expected to be in ' \
                                             f'target batch types: {self.target_batch_types}'
                       
             if batch_type not in self.target_batch_types:
@@ -88,7 +88,7 @@ class SparkETLOperator(SparkOperator):
             entrypoint=self.entrypoint,
             steps=self.steps,
             batch_id=self.batch_id,
-            sequencing_ids=self.sequencing_ids,
+            analysis_ids=self.analysis_ids,
             chromosome=self.chromosome
         )
 

--- a/dags/lib/operators/spark_etl.py
+++ b/dags/lib/operators/spark_etl.py
@@ -39,7 +39,7 @@ class SparkETLOperator(SparkOperator):
                  spark_config: str,
                  entrypoint: str = '',
                  batch_id: str = '',
-                 sequencing_ids: list = '',
+                 sequencing_ids: str = '',
                  chromosome: str = '',
                  target_batch_types: List[ClinAnalysis] = None,
                  detect_batch_type_task_id: str = 'detect_batch_type',
@@ -55,18 +55,11 @@ class SparkETLOperator(SparkOperator):
             skip=skip,
             **kwargs)
 
-        arguments = build_etl_job_arguments(
-            app_name=app_name,
-            entrypoint=entrypoint,
-            steps=steps,
-            batch_id=batch_id,
-            sequencing_ids=sequencing_ids,
-            chromosome=chromosome
-        )
-
-        self.arguments = arguments
+        self.steps = steps
+        self.app_name = app_name
+        self.entrypoint = entrypoint
         self.batch_id = batch_id
-        self.sequencing_ids = sequencing_ids or []
+        self.sequencing_ids = sequencing_ids
         self.chromosome = chromosome
         self.target_batch_types = [target.value for target in (target_batch_types or [])]
         self.detect_batch_type_task_id = detect_batch_type_task_id
@@ -89,5 +82,18 @@ class SparkETLOperator(SparkOperator):
                 raise AirflowSkipException(target_batch_type_message)
             
             logging.info(target_batch_type_message)
+
+        arguments = build_etl_job_arguments(
+            app_name=self.app_name,
+            entrypoint=self.entrypoint,
+            steps=self.steps,
+            batch_id=self.batch_id,
+            sequencing_ids=self.sequencing_ids,
+            chromosome=self.chromosome
+        )
+
+        self.arguments = arguments
+
+        logging.info('Arguments for Spark job: %s', self.arguments)
 
         super().execute(context)

--- a/dags/lib/tasks/batch_type.py
+++ b/dags/lib/tasks/batch_type.py
@@ -75,7 +75,7 @@ def detect(batch_ids: List[str] = None, sequencing_ids: List[str] = None, allowM
 
     logger = logging.getLogger(__name__)
 
-    # in case the parameters are from template renderisng
+    # in case the parameters are from template rendering
     batch_ids = sanitize_list_param(batch_ids)
     sequencing_ids = sanitize_list_param(sequencing_ids)
 

--- a/dags/lib/tasks/batch_type.py
+++ b/dags/lib/tasks/batch_type.py
@@ -1,19 +1,14 @@
 import logging
+from collections import defaultdict
 from typing import Dict, List, Optional
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-
-from lib.config import s3_conn_id, clin_import_bucket
+from lib.config import clin_import_bucket, s3_conn_id
 from lib.datasets import enriched_clinical
-from lib.utils_etl import (
-    metadata_exists,
-    get_metadata_content,
-    ClinSchema,
-    ClinAnalysis,
-    ClinVCFSuffix
-)
+from lib.utils_etl import (ClinAnalysis, ClinSchema, ClinVCFSuffix,
+                           get_metadata_content, metadata_exists)
 
 
 def _validate_snv_vcf_files(s3: S3Hook, batch_id: str, snv_suffix: str):
@@ -50,20 +45,17 @@ def _validate_cnv_vcf_files(metadata: dict, cnv_suffix: str):
                 all_cnv_vcf_valid = False
 
     if not all_cnv_vcf_valid:
-        raise AirflowFailException(f'Not all valid CNV VCF(s) found')
-
+        raise AirflowFailException(f'Not all valid CNV VCF(s) found')@task
 
 # Preserving the old function name and task ID for backward compatibility.
 # In the future, we may consider renaming this to remove references to the batch concept.
 # Note that we restrict amount of activate mapped tasks per DAG to avoid memory issues and delta lake connection problems.
 @task.virtualenv(task_id='detect_batch_type', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
-def detect(batch_id: Optional[str] = None, sequencing_ids: Optional[List[str]] = None) -> Dict[str, str]:
+def detect(batch_ids: List[str] = None, sequencing_ids: List[str] = None, allowMultipleIdentifierTypes: bool = False) -> Dict[str, str]:
     """
-    Returns a dict where the key is the batch id or the sequencing id and the value is the analysis type.
+    Returns a dict where the key is the batch id or the sequencing id and the value are the analysis types.
 
-    Here batch_id and sequencing_ids are mutually exclusive. If both are provided, an exception will be raised.
-
-    If a `batch_id` is provided and the analysis type cannot be determined from the `enriched_clinical` table,
+    If a `batch_ids` is provided and the analysis type cannot be determined from the `enriched_clinical` table,
     the function will attempt to infer the analysis type from the metadata file. If the metadata file does
     not exist, the analysis type will default to `SOMATIC_TUMOR_NORMAL`.
 
@@ -73,30 +65,69 @@ def detect(batch_id: Optional[str] = None, sequencing_ids: Optional[List[str]] =
         - SOMATIC_TUMOR_NORMAL
     """
     import logging
+    from collections import defaultdict
+
     from airflow.exceptions import AirflowFailException
-    from lib.tasks.batch_type import _detect_type_from_enrich_clinical, _detect_type_from_metadata_file
+    from lib.tasks.batch_type import (_detect_type_from_enrich_clinical,
+                                      _detect_type_from_metadata_file)
+    from lib.utils import sanitize_list_param
+    from lib.utils_etl import ClinAnalysis
 
     logger = logging.getLogger(__name__)
 
-    if batch_id and sequencing_ids:
+    # in case the parameters are from template renderisng
+    batch_ids = sanitize_list_param(batch_ids)
+    sequencing_ids = sanitize_list_param(sequencing_ids)
+
+    if len(batch_ids) > 0 and len(sequencing_ids) > 0 and not allowMultipleIdentifierTypes:
         raise AirflowFailException("Only one of batch_id or sequencing_ids can be provided")
 
-    if not (batch_id or sequencing_ids):
-        raise AirflowFailException("Either batch_id or sequencing_ids must be provided")
+    if len(batch_ids) == 0 and len(sequencing_ids) == 0:
+        # we can't raise an airflow skip exception here from a virtual task
+        logger.info("Neither batch_id or sequencing_ids have been provided")
+        return defaultdict(list)
 
-    identifier_to_type = _detect_type_from_enrich_clinical(
-        identifier_column="batch_id" if batch_id else "sequencing_id",
-        identifiers=[batch_id] if batch_id else sequencing_ids,
-        must_exist=bool(sequencing_ids)
+    batch_ids_to_type = _detect_type_from_enrich_clinical(
+        identifier_column="batch_id",
+        identifiers=batch_ids,
+        must_exist=False
     )
-    if not identifier_to_type and batch_id:
-        logger.info(f"Unable to infer batch type for batch ID {batch_id} from the enriched clinical table. Falling back to metadata file.")
-        return _detect_type_from_metadata_file(batch_id)
-    else:
-        return identifier_to_type
 
+    missing_batch_ids = set(batch_ids) - set(batch_ids_to_type.keys())
+    if missing_batch_ids:
+        logger.info(f"Unable to infer batch type for batch ID {missing_batch_ids} from the enriched clinical table. Falling back to metadata file.")
+        batch_ids_to_type |= _detect_type_from_metadata_file(missing_batch_ids)
 
-def _detect_type_from_enrich_clinical(identifier_column, identifiers, must_exist=True):
+    sequencing_ids_to_type = _detect_type_from_enrich_clinical(
+        identifier_column="sequencing_id",
+        identifiers=sequencing_ids,
+        must_exist=True
+    )
+
+    # validate and keep only one type per identifier
+    identifier_to_type = defaultdict(str)
+    for batch_id, types in batch_ids_to_type.items():
+        if len(types) > 1:  # should never happen
+            raise AirflowFailException(f"Batch ID {batch_id} has multiple analysis types: {types}")
+        identifier_to_type[batch_id] = types[0]
+    for sequencing_id, types in sequencing_ids_to_type.items():
+        if sequencing_id in identifier_to_type: # for some reason a batch_id and sequencing_id have the same value
+            raise AirflowFailException(f"Duplicated identifier between batch_id and sequencing_id: {sequencing_id}")
+        # remove SOMATIC_TUMOR_NORMAL if part of the types
+        types = list(filter(lambda type: type != ClinAnalysis.SOMATIC_TUMOR_NORMAL.value, types))
+        if len(types) > 1: # should never happen unless in the future we add new analysis types
+            raise AirflowFailException(f"Sequencing: {sequencing_id} has multiple analysis types: {types}")
+        identifier_to_type[sequencing_id] = types[0]
+
+    # in case the DAG explicitly request one unique analysis type allowed
+    all_types = set(identifier_to_type.values())
+    if len(all_types) > 1 and not allowMultipleIdentifierTypes:
+        raise AirflowFailException(f"DAG doesn't allow multiple analysis types: {all_types}")
+    
+    return identifier_to_type
+   
+
+def _detect_type_from_enrich_clinical(identifier_column: str, identifiers: List[str], must_exist=True) -> Dict[str, List[str]]:
     """
     Returns a dictionary mapping each identifier to its corresponding analysis type.
 
@@ -108,44 +139,51 @@ def _detect_type_from_enrich_clinical(identifier_column, identifiers, must_exist
     The identifiers provided must match the values in the specified `identifier_column`
     of the `enriched_clinical` table.
     """
+    import logging
     from collections import defaultdict
+
     from airflow.exceptions import AirflowFailException
-    from pandas import DataFrame
     from lib.datasets import enriched_clinical
     from lib.utils_etl import BioinfoAnalysisCode
     from lib.utils_etl_tables import to_pandas
+    from pandas import DataFrame
+
+    logger = logging.getLogger(__name__)
 
     df: DataFrame = (
         to_pandas(enriched_clinical.uri)
         .filter([identifier_column, "bioinfo_analysis_code"])
         .set_index(identifier_column)
     )
-    distinct_pairs_df = df[df.index.isin(identifiers)].drop_duplicates()
+    distinct_pairs_df = df[df.index.isin(identifiers)]
 
     identifier_to_codes = defaultdict(list)
+    identifiers_with_unknown_codes = defaultdict(list)
+    identifier_to_types = defaultdict(list)
     for _id, code in distinct_pairs_df.itertuples():
-        identifier_to_codes[_id].append(code)
+        if  code not in identifier_to_codes[_id]: # avoid duplicates
+            identifier_to_codes[_id].append(code)
+            if code not in BioinfoAnalysisCode:
+                identifiers_with_unknown_codes[_id].append(code)
+            else:
+                identifier_to_types[_id].append(BioinfoAnalysisCode(code).to_analysis_type())
 
-    identifiers_with_multiple_codes = {k: v for k, v in identifier_to_codes.items() if len(v) > 1}
-    if identifiers_with_multiple_codes:
-        raise AirflowFailException(f"Multiple bioinfo_analysis_code found for some identifiers: {identifiers_with_multiple_codes}")
+    logger.info(f"Identifiers to analysis type: {identifier_to_codes}")
 
-    identifiers_with_unknown_codes = {k: v for k, v in identifier_to_codes.items() if v[0] not in BioinfoAnalysisCode}
     if identifiers_with_unknown_codes:
         raise AirflowFailException(f"Some identifiers map to unknown codes: {identifiers_with_unknown_codes}")
 
     if must_exist:
         missing_identifiers = set(identifiers) - set(identifier_to_codes.keys())
         if missing_identifiers:
-            raise AirflowFailException(f"IDs not found in clinical data: {missing_identifiers}")
+            raise AirflowFailException(f"IDs of type: {identifier_column} not found in clinical data: {missing_identifiers}")
 
-    identifier_to_type = {k: BioinfoAnalysisCode[v[0]].to_analysis_type() for k, v in identifier_to_codes.items()}
-    return identifier_to_type
+    return identifier_to_types
 
 
-def _detect_type_from_metadata_file(batch_id: str) -> Dict[str, str]:
+def _detect_type_from_metadata_file(batch_ids: List[str]) -> Dict[str, List[str]]:
     """
-    Returns a dict where the key is the batch id and the value is the analysis type.
+    Returns a dict where the key is the batch ids and the value is the analysis type.
 
     The possible analysis types (formerly referred to as batch type) are:
      - GERMLINE
@@ -154,21 +192,27 @@ def _detect_type_from_metadata_file(batch_id: str) -> Dict[str, str]:
     """
     clin_s3 = S3Hook(s3_conn_id)
 
-    if metadata_exists(clin_s3, batch_id):
-        # If the metadata file exists, it's either a GERMLINE or SOMATIC_TUMOR_ONLY analysis
-        metadata = get_metadata_content(clin_s3, batch_id)
-        submission_schema = metadata.get('submissionSchema', '')
-        if submission_schema == ClinSchema.GERMLINE.value:
-            batch_type = ClinAnalysis.GERMLINE.value
-        elif submission_schema == ClinSchema.SOMATIC_TUMOR_ONLY.value:
-            batch_type = ClinAnalysis.SOMATIC_TUMOR_ONLY.value
-        else:
-            raise AirflowFailException(f'Invalid submissionSchema: {submission_schema}')
-    else:
-        # If the metadata file doesn't exist, it's a SOMATIC_TUMOR_NORMAL analysis
-        batch_type = ClinAnalysis.SOMATIC_TUMOR_NORMAL.value
+    identifier_to_types = defaultdict(list)
 
-    return {batch_id: batch_type}
+    for batch_id in batch_ids:
+        batch_type = None
+        if metadata_exists(clin_s3, batch_id):
+            # If the metadata file exists, it's either a GERMLINE or SOMATIC_TUMOR_ONLY analysis
+            metadata = get_metadata_content(clin_s3, batch_id)
+            submission_schema = metadata.get('submissionSchema', '')
+            if submission_schema == ClinSchema.GERMLINE.value:
+                batch_type = ClinAnalysis.GERMLINE.value
+            elif submission_schema == ClinSchema.SOMATIC_TUMOR_ONLY.value:
+                batch_type = ClinAnalysis.SOMATIC_TUMOR_ONLY.value
+            else:
+                raise AirflowFailException(f'Invalid submissionSchema: {submission_schema}')
+        else:
+            # If the metadata file doesn't exist, it's a SOMATIC_TUMOR_NORMAL analysis
+            batch_type = ClinAnalysis.SOMATIC_TUMOR_NORMAL.value
+        identifier_to_types[batch_id] = [batch_type]
+
+    logging.info(f"Batch IDs to analysis type: {identifier_to_types}")
+    return identifier_to_types
 
 
 def skip(batch_type: ClinAnalysis, batch_type_detected: bool,

--- a/dags/lib/tasks/normalize.py
+++ b/dags/lib/tasks/normalize.py
@@ -6,7 +6,7 @@ from lib.utils_etl import ClinAnalysis
 NORMALIZED_MAIN_CLASS = 'bio.ferlab.clin.etl.normalized.RunNormalized'
 
 
-def snv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def snv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv',
         task_id='snv',
@@ -18,12 +18,12 @@ def snv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalys
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def snv_somatic(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def snv_somatic(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv_somatic',
         task_id='snv_somatic',
@@ -35,12 +35,12 @@ def snv_somatic(batch_id: str, sequencing_ids: list, target_batch_types: List[Cl
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def cnv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv',
         task_id='cnv',
@@ -52,12 +52,12 @@ def cnv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalys
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def cnv_somatic_tumor_only(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv_somatic_tumor_only(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv_somatic_tumor_only',
         task_id='cnv_somatic_tumor_only',
@@ -69,12 +69,12 @@ def cnv_somatic_tumor_only(batch_id: str, sequencing_ids: list, target_batch_typ
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def variants(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def variants(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='variants',
         task_id='variants',
@@ -86,12 +86,12 @@ def variants(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinA
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def consequences(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def consequences(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='consequences',
         task_id='consequences',
@@ -103,12 +103,12 @@ def consequences(batch_id: str, sequencing_ids: list, target_batch_types: List[C
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def coverage_by_gene(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def coverage_by_gene(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='coverage_by_gene',
         task_id='coverage_by_gene',
@@ -120,12 +120,12 @@ def coverage_by_gene(batch_id: str, sequencing_ids: list, target_batch_types: Li
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def exomiser(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def exomiser(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='exomiser',
         task_id='exomiser',
@@ -137,12 +137,12 @@ def exomiser(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinA
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )
 
 
-def franklin(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def franklin(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='franklin',
         task_id='franklin',
@@ -154,6 +154,6 @@ def franklin(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinA
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
-        sequencing_ids=sequencing_ids,
+        analysis_ids=analysis_ids,
         target_batch_types=target_batch_types
     )

--- a/dags/lib/tasks/normalize.py
+++ b/dags/lib/tasks/normalize.py
@@ -6,7 +6,7 @@ from lib.utils_etl import ClinAnalysis
 NORMALIZED_MAIN_CLASS = 'bio.ferlab.clin.etl.normalized.RunNormalized'
 
 
-def snv(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def snv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv',
         task_id='snv',
@@ -18,10 +18,12 @@ def snv(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_jar=spark_jar,
         skip=skip,
         batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def snv_somatic(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def snv_somatic(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv_somatic',
         task_id='snv_somatic',
@@ -32,11 +34,13 @@ def snv_somatic(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def cnv(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv',
         task_id='cnv',
@@ -47,11 +51,13 @@ def cnv(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def cnv_somatic_tumor_only(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv_somatic_tumor_only(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv_somatic_tumor_only',
         task_id='cnv_somatic_tumor_only',
@@ -62,11 +68,13 @@ def cnv_somatic_tumor_only(batch_id: str, spark_jar: str, skip: str) -> SparkETL
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def variants(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def variants(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='variants',
         task_id='variants',
@@ -77,11 +85,13 @@ def variants(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def consequences(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def consequences(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='consequences',
         task_id='consequences',
@@ -92,11 +102,13 @@ def consequences(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def coverage_by_gene(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def coverage_by_gene(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='coverage_by_gene',
         task_id='coverage_by_gene',
@@ -107,11 +119,13 @@ def coverage_by_gene(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperat
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def exomiser(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def exomiser(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='exomiser',
         task_id='exomiser',
@@ -122,11 +136,13 @@ def exomiser(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )
 
 
-def franklin(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
+def franklin(batch_id: str, sequencing_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='franklin',
         task_id='franklin',
@@ -137,5 +153,7 @@ def franklin(batch_id: str, spark_jar: str, skip: str) -> SparkETLOperator:
         spark_config='config-etl-large',
         spark_jar=spark_jar,
         skip=skip,
-        batch_id=batch_id
+        batch_id=batch_id,
+        sequencing_ids=sequencing_ids,
+        target_batch_types=target_batch_types
     )

--- a/dags/lib/tasks/params_validate.py
+++ b/dags/lib/tasks/params_validate.py
@@ -21,9 +21,9 @@ def validate_release_color(release_id: str, color: str):
 
 
 @task(task_id='params_validate', on_execute_callback=Slack.notify_dag_start)
-def validate_batch_sequencing_ids_color(batch_id: str, sequencing_ids: str, color: str):
-    if batch_id == '' and sequencing_ids == '':
-        raise AirflowFailException('DAG param "batch_id" or "sequencing_ids" is required')
+def validate_batch_analysis_ids_color(batch_id: str, analysis_ids: str, color: str):
+    if batch_id == '' and analysis_ids == '':
+        raise AirflowFailException('DAG param "batch_id" or "analysis_ids" is required')
     if env == Env.QA:
         if not color or color == '':
             raise AirflowFailException(
@@ -60,7 +60,7 @@ def get_batch_ids(ti=None) -> list:
     # try to keep the somatic_normal imported last
     return sorted(set(ids), key=lambda x: (x.endswith("somatic_normal"), x)) 
 
-@task(task_id='get_sequencing_ids')
-def get_sequencing_ids(ti=None) -> list:
+@task(task_id='get_analysis_ids')
+def get_analysis_ids(ti=None) -> list:
     dag_run: DagRun = ti.dag_run
-    return dag_run.conf['sequencing_ids'] if dag_run.conf['sequencing_ids'] is not None else []
+    return dag_run.conf['analysis_ids'] if dag_run.conf['analysis_ids'] is not None else []

--- a/dags/lib/tasks/params_validate.py
+++ b/dags/lib/tasks/params_validate.py
@@ -58,7 +58,7 @@ def get_batch_ids(ti=None) -> list:
     dag_run: DagRun = ti.dag_run
     ids = dag_run.conf['batch_ids'] if dag_run.conf['batch_ids'] is not None else []
     # try to keep the somatic_normal imported last
-    return sorted(list(set(ids)), key=lambda x: x.endswith("somatic_normal"))
+    return sorted(set(ids), key=lambda x: (x.endswith("somatic_normal"), x)) 
 
 @task(task_id='get_sequencing_ids')
 def get_sequencing_ids(ti=None) -> list:

--- a/dags/lib/tasks/params_validate.py
+++ b/dags/lib/tasks/params_validate.py
@@ -53,6 +53,13 @@ def validate_color(color: str):
             f'DAG param "color" is forbidden in {env} environment'
         )
 
+@task(task_id='get_batch_ids')
+def get_batch_ids(ti=None) -> list:
+    dag_run: DagRun = ti.dag_run
+    ids = dag_run.conf['batch_ids'] if dag_run.conf['batch_ids'] is not None else []
+    # try to keep the somatic_normal imported last
+    return sorted(list(set(ids)), key=lambda x: x.endswith("somatic_normal"))
+
 @task(task_id='get_sequencing_ids')
 def get_sequencing_ids(ti=None) -> list:
     dag_run: DagRun = ti.dag_run

--- a/dags/lib/utils.py
+++ b/dags/lib/utils.py
@@ -43,10 +43,3 @@ def urlsafe_hash(obj: Any, length: int) -> str:
     hash_obj = hashlib.sha256(utf8_str).digest()
     base64_str = base64.urlsafe_b64encode(hash_obj).decode('utf-8').rstrip('=')  # Encoding to base64 allows for more compact representation (more bits per character)
     return base64_str[:length]
-
-def sanitize_list_param(lst: Any) -> list[str]:
-    if type(lst) is str and lst.strip() != "":
-        lst = [lst]
-    if lst and len(lst) > 0 and all(s.strip() != "" for s in lst):
-        return lst
-    return []

--- a/dags/lib/utils.py
+++ b/dags/lib/utils.py
@@ -45,8 +45,8 @@ def urlsafe_hash(obj: Any, length: int) -> str:
     return base64_str[:length]
 
 def sanitize_list_param(lst: Any) -> list[str]:
-    if type(lst) is str:
+    if type(lst) is str and lst.strip() != "":
         lst = [lst]
-    if lst and len(lst) > 0 and all(s != "" for s in lst):
+    if lst and len(lst) > 0 and all(s.strip() != "" for s in lst):
         return lst
     return []

--- a/dags/lib/utils.py
+++ b/dags/lib/utils.py
@@ -1,9 +1,9 @@
 import base64
 import hashlib
 import json
+from typing import Any, List
 
 import requests
-from typing import Any, List
 
 
 def join(string: str, parts: List[str]) -> str:
@@ -43,3 +43,10 @@ def urlsafe_hash(obj: Any, length: int) -> str:
     hash_obj = hashlib.sha256(utf8_str).digest()
     base64_str = base64.urlsafe_b64encode(hash_obj).decode('utf-8').rstrip('=')  # Encoding to base64 allows for more compact representation (more bits per character)
     return base64_str[:length]
+
+def sanitize_list_param(lst: Any) -> list[str]:
+    if type(lst) is str:
+        lst = [lst]
+    if lst and len(lst) > 0 and all(s != "" for s in lst):
+        return lst
+    return []

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -132,7 +132,7 @@ def build_etl_job_arguments(
     if batch_id:
         arguments = arguments + ['--batchId', batch_id]
     if sequencing_ids:
-        arguments = arguments + ['--sequencing_ids', sequencing_ids] # probably wont work out of the box, cause sequencing_ids is a XCom param
+        arguments = arguments + ['--sequencingId', sequencing_ids] # probably wont work out of the box, cause sequencing_ids is a XCom param
     if chromosome:
         arguments = arguments + ['--chromosome', f'chr{chromosome}']
     return arguments

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -1,9 +1,8 @@
 import json
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-
 from lib import config
 from lib.config import clin_import_bucket, config_file
 
@@ -44,6 +43,8 @@ class BioinfoAnalysisCode(Enum):
 def batch_id() -> str:
     return '{{ params.batch_id or "" }}'
 
+def sequencing_ids():
+    return '{{ params.sequencing_ids or "" }}'
 
 def release_id(index: Optional[str] = None) -> str:
     if not index:

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -45,8 +45,8 @@ class BioinfoAnalysisCode(Enum):
 def batch_id() -> str:
     return '{{ params.batch_id or "" }}'
 
-def sequencing_ids():
-    return '{{ params.sequencing_ids or "" }}'
+def analysis_ids():
+    return '{{ params.analysis_ids or "" }}'
 
 def release_id(index: Optional[str] = None) -> str:
     if not index:
@@ -120,7 +120,7 @@ def build_etl_job_arguments(
         entrypoint: Optional[str] = None,
         steps: str = "default",
         batch_id: Optional[str] = None,
-        sequencing_ids: Optional[list[str]] = None,
+        analysis_ids: Optional[list[str]] = None,
         chromosome: Optional[str] = None) -> List[str]:
     arguments = [
             '--config', config_file,
@@ -131,8 +131,8 @@ def build_etl_job_arguments(
         arguments = [entrypoint] + arguments
     if batch_id and batch_id != '':
         arguments = arguments + ['--batchId', batch_id]
-    if sequencing_ids and len(sequencing_ids) > 0:
-        arguments = arguments + ['--sequencingId', ','.join(sequencing_ids)]
+    if analysis_ids and len(analysis_ids) > 0:
+        arguments = arguments + ['--analysisId', ','.join(analysis_ids)]
     if chromosome:
         arguments = arguments + ['--chromosome', f'chr{chromosome}']
     return arguments
@@ -142,29 +142,29 @@ def get_ingest_dag_configs_by_batch_id(batch_id: str, ti=None) -> dict:
     dag_run: DagRun = ti.dag_run
     return {
         'batch_id': batch_id,
-        'sequencing_ids': None,
+        'analysis_ids': None,
         'color': dag_run.conf['color'],
         'import': dag_run.conf['import'],
         'spark_jar': dag_run.conf['spark_jar']
     }
     
-@task(task_id='get_ingest_dag_configs_by_sequencing_ids')
-def get_ingest_dag_configs_by_sequencing_ids(all_batch_types: Dict[str, str], sequencing_ids: List[str], analysisType: str, ti=None) -> dict:
+@task(task_id='get_ingest_dag_configs_by_analysis_ids')
+def get_ingest_dag_configs_by_analysis_ids(all_batch_types: Dict[str, str], analysis_ids: List[str], analysisType: str, ti=None) -> dict:
     dag_run: DagRun = ti.dag_run
 
-    # try regroup sequencing ids and generate a config of etl_ingest for each analysis type
+    # try regroup analysis ids and generate a config of etl_ingest for each analysis type
 
-    sequencing_ids_compatible_with_type = []
+    analysis_ids_compatible_with_type = []
     for identifier, type in all_batch_types.items():
-        if analysisType == type and identifier in sequencing_ids:
-            sequencing_ids_compatible_with_type.append(identifier)
+        if analysisType == type and identifier in analysis_ids:
+            analysis_ids_compatible_with_type.append(identifier)
 
-    if len(sequencing_ids_compatible_with_type) == 0:
-        return None # No sequencing ids found for that analysis type
+    if len(analysis_ids_compatible_with_type) == 0:
+        return None # No analysis ids found for that analysis type
 
     return {
         'batch_id': None,
-        'sequencing_ids': sequencing_ids_compatible_with_type,
+        'analysis_ids': analysis_ids_compatible_with_type,
         'color': dag_run.conf['color'],
         'import': dag_run.conf['import'],
         'spark_jar': dag_run.conf['spark_jar']

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -120,6 +120,7 @@ def build_etl_job_arguments(
         entrypoint: Optional[str] = None,
         steps: str = "default",
         batch_id: Optional[str] = None,
+        sequencing_ids: Optional[str] = None,
         chromosome: Optional[str] = None) -> List[str]:
     arguments = [
             '--config', config_file,
@@ -130,6 +131,8 @@ def build_etl_job_arguments(
         arguments = [entrypoint] + arguments
     if batch_id:
         arguments = arguments + ['--batchId', batch_id]
+    if sequencing_ids:
+        arguments = arguments + ['--sequencing_ids', sequencing_ids] # probably wont work out of the box, cause sequencing_ids is a XCom param
     if chromosome:
         arguments = arguments + ['--chromosome', f'chr{chromosome}']
     return arguments

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -120,7 +120,7 @@ def build_etl_job_arguments(
         entrypoint: Optional[str] = None,
         steps: str = "default",
         batch_id: Optional[str] = None,
-        sequencing_ids: Optional[str] = None,
+        sequencing_ids: Optional[list[str]] = None,
         chromosome: Optional[str] = None) -> List[str]:
     arguments = [
             '--config', config_file,
@@ -129,10 +129,10 @@ def build_etl_job_arguments(
     ]
     if entrypoint:
         arguments = [entrypoint] + arguments
-    if batch_id:
+    if batch_id and batch_id != '':
         arguments = arguments + ['--batchId', batch_id]
-    if sequencing_ids:
-        arguments = arguments + ['--sequencingId', sequencing_ids] # probably wont work out of the box, cause sequencing_ids is a XCom param
+    if sequencing_ids and len(sequencing_ids) > 0:
+        arguments = arguments + ['--sequencingId', ','.join(sequencing_ids)]
     if chromosome:
         arguments = arguments + ['--chromosome', f'chr{chromosome}']
     return arguments

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       test: ["CMD", "pg_isready", "-U", "airflow"]
       interval: 5s
       retries: 5
-    restart: always
+    restart: unless-stopped
 
   redis:
     image: redis:latest
@@ -53,7 +53,7 @@ services:
       interval: 5s
       timeout: 30s
       retries: 50
-    restart: always
+    restart: unless-stopped
 
   airflow-webserver:
     <<: *airflow-common
@@ -65,7 +65,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -79,7 +79,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped 
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -98,7 +98,7 @@ services:
     environment:
       <<: *airflow-common-env
       DUMB_INIT_SETSID: "0"
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -112,7 +112,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:
@@ -158,7 +158,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:


### PR DESCRIPTION
PR qui rajoute la possibilitee de passer `sequencing_ids` en param de:
- `etl`
- `etl_ingest`

Cela s'inscrit dans la futur flot ou `etl_run`, une fois la generation des VCFs, Exomisers termine, pourra appeler `etl` avec la liste des sequening_ids et realiser une release comme on a l'habitude de faire de facon transparente.

*La scope de la PR a ete volontairement reduit et n'inclut pas la partie ou les ids sont propages dans le code et envoyes vers les ETLs, ca faisait trop gros.*

**Le but de la PR est aussi de rester retro-compatible avec l'existant, tout les endroit qui utilisent `detect_batch_type` pour savoir ce qui doit etre skip ou pas.**

Voici a quoi ressemble `etl`:

![Screenshot from 2025-06-06 21-52-35](https://github.com/user-attachments/assets/58ad308b-2f40-499a-bb15-de2888e73c6a)

Vous avez ici un exemple ou un ensemble de batchs ainsi que de sequencings ont ete envoyes en param, `etl` accepte ce cas mais `etl_ingest` va se plaindre si on lui demande de se lancer sur des choses qui ont des analyses type differents. `etl` va donc realiser un routage:

1) tout ce qui est batch id est lance comme avant: un `etl_ingest` par batch_id
2) les sequencing ids sont regroupes par type de batch germine, somatic et on lance `etl_ingest` soit 1 ou 2 fois.
3) toutes les fonctions qui se basent sur le `task_instance.xcom_pull(task_ids='detect_batch_type')` devraient toujours foncitonner pour determiner ce qui doit etre fait ou skip.

Ainsi `etl_ingest` se retrouve toujours dans une situation ou une run = 1x batch type ce qui permet de garder toute la logique existante.

`detect_batch_type` a eut bcp de modifs et d'aller-retours d'idees, dont on peut discuter.

