### PR TITLE
feat: CLIN-4690 update clin-variant-etl version to 3.13.0

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -83,7 +83,7 @@ elif env == Env.QA:
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 'clin-variant-etl-v3.12.0.jar'
+    spark_jar = 'clin-variant-etl-v3.13.0.jar'
     obo_parser_spark_jar = 'obo-parser-v1.1.0.jar' # deploy from https://github.com/Ferlab-Ste-Justine/obo-parser/tree/clin-v1.x.0
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'


### PR DESCRIPTION
Bumping clin-variant-etl version to 3.13.0. Change is done in QA environment only.

This version is using new partitioning by analysis_id and bioinfo_analysis_code for tables normalized_snv_somatic and enriched_snv_somatic