### PR TITLE
fix: CLIN-4878 make sure nextflow pod arguments are converted to string

### DIFF
--- a/dags/lib/operators/nextflow.py
+++ b/dags/lib/operators/nextflow.py
@@ -83,7 +83,9 @@ class NextflowOperator(BaseKubernetesOperator):
         nextflow_revision_option = ['-r', self.nextflow_pipeline_revision] if self.nextflow_pipeline_revision else []
         nextflow_config_file_options = [arg for file in self.nextflow_config_files for arg in ['-c', file] if file]
         nextflow_params_file_option = ['-params-file', self.nextflow_params_file] if self.nextflow_params_file else []
-        arguments = [arg for arg in self.arguments if arg] if self.arguments else []  # Remove empty strings
+        
+        # Remove empty strings and ensure all arguments are strings
+        arguments = [str(arg) for arg in self.arguments if str(arg)] if self.arguments else []
 
         self.arguments = ['nextflow', *nextflow_config_file_options, 'run', self.nextflow_pipeline,
                           *nextflow_revision_option, *nextflow_params_file_option, *arguments]


### PR DESCRIPTION
To address:
https://ferlab-crsj.atlassian.net/browse/CLIN-4878

When `render_template_as_native_obj` is set to True, some Nextflow pod arguments may be automatically converted to non-string objects (e.g., "5" becomes 5). However, the Kubernetes API only supports string values for pod arguments.

To prevent issues, this PR adds a step to explicitly convert all Nextflow pod arguments to strings after Jinja templating is applied.

**Tests**
Tested locally using a test DAG. I reproduced the bug, applied the fix, and re-ran the DAG to confirm that the issue was resolved.

