### PR TITLE
fix: CLIN-4897 bump clin-variant-etl to v3.17.1

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -83,7 +83,7 @@ elif env == Env.QA:
     pipeline_image = 'ferlabcrsj/clin-pipelines'
     panels_image = 'ferlabcrsj/clin-panels:13b8182d493658f2c6e0583bc275ba26967667ab-1683653903'
     es_url = 'http://elasticsearch:9200'
-    spark_jar = 'clin-variant-etl-v3.17.0.jar'
+    spark_jar = 'clin-variant-etl-v3.17.1.jar'
     obo_parser_spark_jar = 'obo-parser-v1.1.0.jar' # deploy from https://github.com/Ferlab-Ste-Justine/obo-parser/tree/clin-v1.x.0
     ca_certificates = 'ingress-ca-certificate'
     minio_certificate = 'minio-ca-certificate'


### PR DESCRIPTION
To benefit a correction in the partitioning of table normalized_coverage_by_gene