### PR TITLE
fix: CLIN-4681 - etl migrate expand + auto batch_ids

### DIFF
--- a/dags/etl_migrate.py
+++ b/dags/etl_migrate.py
@@ -58,7 +58,7 @@ with DAG(
         dag_run: DagRun = ti.dag_run
         return {
             'batch_id': batch_id,
-            'skip_export_fhir': 'no', # export already done here, required if etl_migrate_batch is launch manually
+            'export_fhir': 'no', # export already done here, required if etl_migrate_batch is launch manually
             'color': dag_run.conf['color'],
             'snv': dag_run.conf['snv'],
             'snv_somatic': dag_run.conf['snv_somatic'],

--- a/dags/etl_migrate.py
+++ b/dags/etl_migrate.py
@@ -1,21 +1,17 @@
 from datetime import datetime
 
 from airflow import DAG
+from airflow.decorators import task
+from airflow.models import DagRun
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
-from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
-from lib.config import batch_ids
 from lib.groups.ingest.ingest_fhir import ingest_fhir
-from lib.groups.migrate.migrate_germline import migrate_germline
-from lib.groups.migrate.migrate_somatic_tumor_normal import \
-    migrate_somatic_tumor_normal
-from lib.groups.migrate.migrate_somatic_tumor_only import \
-    migrate_somatic_tumor_only
+from lib.operators.trigger_dagrun import TriggerDagRunOperator
 from lib.slack import Slack
 from lib.tasks import batch_type
 from lib.tasks.params_validate import validate_color
-from lib.utils_etl import color, get_group_id, spark_jar
+from lib.utils_etl import color, spark_jar
 
 with DAG(
         dag_id='etl_migrate',
@@ -40,61 +36,15 @@ with DAG(
             'trigger_rule': TriggerRule.NONE_FAILED,
             'on_failure_callback': Slack.notify_task_failure,
         },
-        max_active_tasks=4
+        max_active_tasks=4,
+        max_active_runs=1,
 ) as dag:
-    def format_skip_condition(param: str) -> str:
-        return '{% if params.' + param + ' == "yes" %}{% else %}yes{% endif %}'
-
-
-    def skip_snv() -> str:
-        return format_skip_condition('snv')
-
-
-    def skip_snv_somatic() -> str:
-        return format_skip_condition('snv_somatic')
-
-
-    def skip_cnv() -> str:
-        return format_skip_condition('cnv')
-
-
-    def skip_cnv_somatic_tumor_only() -> str:
-        return format_skip_condition('cnv_somatic_tumor_only')
-
-
-    def skip_variants() -> str:
-        return format_skip_condition('variants')
-
-
-    def skip_consequences() -> str:
-        return format_skip_condition('consequences')
-
-
-    def skip_exomiser() -> str:
-        return format_skip_condition('exomiser')
-    
-    
-    def skip_exomiser_cnv() -> str:
-        return format_skip_condition('exomiser_cnv')
-    
-
-    def skip_coverage_by_gene() -> str:
-        return format_skip_condition('coverage_by_gene')
-
-
-    def skip_franklin() -> str:
-        return format_skip_condition('franklin')
-
-
-    def skip_nextflow() -> str:
-        return format_skip_condition('nextflow')
-
 
     params_validate_task = validate_color(
         color=color()
     )
 
-    all_dags = ingest_fhir(
+    ingest_fhir_task = ingest_fhir(
         batch_ids=[],
         color=color(),
         skip_all='',
@@ -103,62 +53,39 @@ with DAG(
         spark_jar=spark_jar(),
     )
 
-    params_validate_task >> all_dags
+    @task(task_id='get_migrate_batch_dag_config')
+    def get_migrate_batch_dag_config(batch_id: str, ti=None) -> dict:
+        dag_run: DagRun = ti.dag_run
+        return {
+            'batch_id': batch_id,
+            'skip_export_fhir': 'no', # export already done here, required if etl_migrate_batch is launch manually
+            'color': dag_run.conf['color'],
+            'snv': dag_run.conf['snv'],
+            'snv_somatic': dag_run.conf['snv_somatic'],
+            'cnv': dag_run.conf['cnv'],
+            'cnv_somatic_tumor_only': dag_run.conf['cnv_somatic_tumor_only'],
+            'variants': dag_run.conf['variants'],
+            'consequences':dag_run.conf['consequences'],
+            'exomiser':dag_run.conf['exomiser'],
+            'exomiser_cnv': dag_run.conf['exomiser_cnv'],
+            'coverage_by_gene':dag_run.conf['coverage_by_gene'],
+            'franklin':dag_run.conf['franklin'],
+            'nextflow':dag_run.conf['nextflow'],
+            'spark_jar': dag_run.conf['spark_jar'],
+        }
 
+    get_all_batch_ids_task = batch_type.get_all_batch_ids()
+    get_migrate_batch_dag_config_task = get_migrate_batch_dag_config.expand(batch_id=get_all_batch_ids_task)
 
-    def migrate_batch_id(batch_id: str) -> TaskGroup:
-        with TaskGroup(group_id=get_group_id('migrate', batch_id)) as group:
-            detect_batch_type_task = batch_type.detect(batch_id=batch_id)
-
-            migrate_germline_group = migrate_germline(
-                batch_id=batch_id,
-                skip_snv=skip_snv(),
-                skip_cnv=skip_cnv(),
-                skip_variants=skip_variants(),
-                skip_consequences=skip_consequences(),
-                skip_exomiser=skip_exomiser(),
-                skip_exomiser_cnv=skip_exomiser_cnv(),
-                skip_coverage_by_gene=skip_coverage_by_gene(),
-                skip_franklin=skip_franklin(),
-                skip_nextflow=skip_nextflow(),
-                spark_jar=spark_jar()
-            )
-
-            migrate_somatic_tumor_only_group = migrate_somatic_tumor_only(
-                batch_id=batch_id,
-                skip_snv_somatic=skip_snv_somatic(),
-                skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only(),
-                skip_variants=skip_variants(),
-                skip_consequences=skip_consequences(),
-                skip_coverage_by_gene=skip_coverage_by_gene(),
-                spark_jar=spark_jar()
-            )
-
-            migrate_somatic_tumor_normal_group = migrate_somatic_tumor_normal(
-                batch_id=batch_id,
-                skip_snv_somatic=skip_snv_somatic(),
-                skip_variants=skip_variants(),
-                skip_consequences=skip_consequences(),
-                skip_coverage_by_gene=skip_coverage_by_gene(),
-                spark_jar=spark_jar()
-            )
-
-            detect_batch_type_task >> [migrate_germline_group,
-                                       migrate_somatic_tumor_only_group,
-                                       migrate_somatic_tumor_normal_group]
-
-        return group
-
-
-    # concat every dags inside a loop
-    for batch_id in sorted(set(batch_ids)):
-        batch = migrate_batch_id(batch_id)
-        all_dags >> batch
-        all_dags = batch
+    trigger_migrate_batch_dags = TriggerDagRunOperator.partial(
+        task_id='etl_migrate_batch',
+        trigger_dag_id='etl_migrate_batch',
+        wait_for_completion=True
+    ).expand(conf=get_migrate_batch_dag_config_task)
 
     slack = EmptyOperator(
         task_id="slack",
         on_success_callback=Slack.notify_dag_completion,
     )
 
-    all_dags >> slack
+    params_validate_task >> ingest_fhir_task >> get_all_batch_ids_task >> trigger_migrate_batch_dags >> slack

--- a/dags/etl_migrate_batch.py
+++ b/dags/etl_migrate_batch.py
@@ -1,0 +1,156 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models.param import Param
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.task_group import TaskGroup
+from airflow.utils.trigger_rule import TriggerRule
+from lib.config import batch_ids
+from lib.groups.ingest.ingest_fhir import ingest_fhir
+from lib.groups.migrate.migrate_germline import migrate_germline
+from lib.groups.migrate.migrate_somatic_tumor_normal import \
+    migrate_somatic_tumor_normal
+from lib.groups.migrate.migrate_somatic_tumor_only import \
+    migrate_somatic_tumor_only
+from lib.slack import Slack
+from lib.tasks import batch_type
+from lib.tasks.params_validate import validate_color
+from lib.utils_etl import batch_id, color, get_group_id, spark_jar
+
+with DAG(
+        dag_id='etl_migrate_batch',
+        start_date=datetime(2022, 1, 1),
+        schedule=None,
+        params={
+            'batch_id': Param('', type=['null', 'string']),
+            'export_fhir': Param('yes', enum=['yes', 'no']),
+            'color': Param('', type=['null', 'string']),
+            'snv': Param('no', enum=['yes', 'no']),
+            'snv_somatic': Param('no', enum=['yes', 'no']),
+            'cnv': Param('no', enum=['yes', 'no']),
+            'cnv_somatic_tumor_only': Param('no', enum=['yes', 'no']),
+            'variants': Param('no', enum=['yes', 'no']),
+            'consequences': Param('no', enum=['yes', 'no']),
+            'exomiser': Param('no', enum=['yes', 'no']),
+            'exomiser_cnv': Param('no', enum=['yes', 'no']),
+            'coverage_by_gene': Param('no', enum=['yes', 'no']),
+            'franklin': Param('no', enum=['yes', 'no']),
+            'nextflow': Param('no', enum=['yes', 'no']),
+            'spark_jar': Param('', type=['null', 'string']),
+        },
+        default_args={
+            'trigger_rule': TriggerRule.NONE_FAILED,
+            'on_failure_callback': Slack.notify_task_failure,
+        },
+        max_active_tasks=4,
+        max_active_runs=1,
+) as dag:
+    def format_skip_condition(param: str) -> str:
+        return '{% if params.' + param + ' == "yes" %}{% else %}yes{% endif %}'
+
+    def skip_export_fhir() -> str:
+        return format_skip_condition('export_fhir')
+    
+    def skip_snv() -> str:
+        return format_skip_condition('snv')
+
+
+    def skip_snv_somatic() -> str:
+        return format_skip_condition('snv_somatic')
+
+
+    def skip_cnv() -> str:
+        return format_skip_condition('cnv')
+
+
+    def skip_cnv_somatic_tumor_only() -> str:
+        return format_skip_condition('cnv_somatic_tumor_only')
+
+
+    def skip_variants() -> str:
+        return format_skip_condition('variants')
+
+
+    def skip_consequences() -> str:
+        return format_skip_condition('consequences')
+
+
+    def skip_exomiser() -> str:
+        return format_skip_condition('exomiser')
+    
+    
+    def skip_exomiser_cnv() -> str:
+        return format_skip_condition('exomiser_cnv')
+    
+
+    def skip_coverage_by_gene() -> str:
+        return format_skip_condition('coverage_by_gene')
+
+
+    def skip_franklin() -> str:
+        return format_skip_condition('franklin')
+
+
+    def skip_nextflow() -> str:
+        return format_skip_condition('nextflow')
+
+
+    params_validate_task = validate_color(
+        color=color()
+    )
+
+    ingest_fhir_task = ingest_fhir(
+        batch_ids=[],
+        color=color(),
+        skip_all=skip_export_fhir(),
+        skip_import='yes',  # always skip import, not the purpose of that dag
+        skip_batch='',  # we want to do fhir normalized once
+        spark_jar=spark_jar(),
+    )
+
+    detect_batch_type_task = batch_type.detect(batch_id=batch_id())
+
+    migrate_germline_group = migrate_germline(
+        batch_id=batch_id(),
+        skip_snv=skip_snv(),
+        skip_cnv=skip_cnv(),
+        skip_variants=skip_variants(),
+        skip_consequences=skip_consequences(),
+        skip_exomiser=skip_exomiser(),
+        skip_exomiser_cnv=skip_exomiser_cnv(),
+        skip_coverage_by_gene=skip_coverage_by_gene(),
+        skip_franklin=skip_franklin(),
+        skip_nextflow=skip_nextflow(),
+        spark_jar=spark_jar()
+    )
+
+    migrate_somatic_tumor_only_group = migrate_somatic_tumor_only(
+        batch_id=batch_id(),
+        skip_snv_somatic=skip_snv_somatic(),
+        skip_cnv_somatic_tumor_only=skip_cnv_somatic_tumor_only(),
+        skip_variants=skip_variants(),
+        skip_consequences=skip_consequences(),
+        skip_coverage_by_gene=skip_coverage_by_gene(),
+        spark_jar=spark_jar()
+    )
+
+    migrate_somatic_tumor_normal_group = migrate_somatic_tumor_normal(
+        batch_id=batch_id(),
+        skip_snv_somatic=skip_snv_somatic(),
+        skip_variants=skip_variants(),
+        skip_consequences=skip_consequences(),
+        skip_coverage_by_gene=skip_coverage_by_gene(),
+        spark_jar=spark_jar()
+    )
+
+    detect_batch_type_task >> [migrate_germline_group,
+                                migrate_somatic_tumor_only_group,
+                                migrate_somatic_tumor_normal_group]
+
+    slack = EmptyOperator(
+        task_id="slack",
+        on_success_callback=Slack.notify_dag_completion,
+    )
+
+    params_validate_task >> ingest_fhir_task >> detect_batch_type_task >> migrate_germline_group >> migrate_somatic_tumor_only_group >> migrate_somatic_tumor_normal_group >> slack

--- a/dags/lib/groups/migrate/migrate_germline.py
+++ b/dags/lib/groups/migrate/migrate_germline.py
@@ -18,11 +18,10 @@ def migrate_germline(
         skip_nextflow: str,
         spark_jar: str
 ):
-    detect_batch_type_task_id = f"{get_group_id('migrate', batch_id)}.detect_batch_type"
+
     skip_all = batch_type.skip(
         batch_type=ClinAnalysis.GERMLINE,
         batch_type_detected=True,
-        detect_batch_type_task_id=detect_batch_type_task_id
     )
 
     validate_germline_task = batch_type.validate(

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_normal.py
@@ -14,11 +14,9 @@ def migrate_somatic_tumor_normal(
         skip_coverage_by_gene: str,
         spark_jar: str
 ):
-    detect_batch_type_task_id = f"{get_group_id('migrate', batch_id)}.detect_batch_type"
     skip_all = batch_type.skip(
         batch_type=ClinAnalysis.SOMATIC_TUMOR_NORMAL,
         batch_type_detected=True,
-        detect_batch_type_task_id=detect_batch_type_task_id
     )
 
     validate_somatic_tumor_normal_task = batch_type.validate(

--- a/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
+++ b/dags/lib/groups/migrate/migrate_somatic_tumor_only.py
@@ -15,11 +15,9 @@ def migrate_somatic_tumor_only(
         skip_coverage_by_gene: str,
         spark_jar: str
 ):
-    detect_batch_type_task_id = f"{get_group_id('migrate', batch_id)}.detect_batch_type"
     skip_all = batch_type.skip(
         batch_type=ClinAnalysis.SOMATIC_TUMOR_ONLY,
         batch_type_detected=True,
-        detect_batch_type_task_id=detect_batch_type_task_id
     )
 
     validate_somatic_tumor_only_task = batch_type.validate(

--- a/dags/lib/groups/normalize/normalize_germline.py
+++ b/dags/lib/groups/normalize/normalize_germline.py
@@ -25,24 +25,25 @@ def normalize_germline(
         skip_franklin: str,
         skip_nextflow: str,
         spark_jar: str,
+        detect_batch_type_task_id: str = None,
 ):
     
     target_batch_types = [ClinAnalysis.GERMLINE]
 
-    snv = normalize.snv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv))
-    cnv = normalize.cnv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv))
-    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    exomiser = normalize.exomiser(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser))
-    exomiser_cnv = normalize.exomiser_cnv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser_cnv))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv = normalize.snv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv), detect_batch_type_task_id)
+    cnv = normalize.cnv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv), detect_batch_type_task_id)
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants), detect_batch_type_task_id)
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences), detect_batch_type_task_id)
+    exomiser = normalize.exomiser(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser), detect_batch_type_task_id)
+    exomiser_cnv = normalize.exomiser_cnv(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_exomiser_cnv), detect_batch_type_task_id)
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene), detect_batch_type_task_id)
 
     franklin_update_task = franklin_update(
         analysis_ids=analysis_ids,
         skip=skip(skip_all, skip_franklin)
     )
 
-    franklin = normalize.franklin(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_franklin))
+    franklin = normalize.franklin(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_franklin), detect_batch_type_task_id)
 
     @task_group(group_id="nextflow")
     def nextflow_group():

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_normal.py
@@ -13,13 +13,14 @@ def normalize_somatic_tumor_normal(
         skip_consequences: str,
         skip_coverage_by_gene: str,
         spark_jar: str,
+        detect_batch_type_task_id: str = None,
 ):
     
     target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_NORMAL]
 
-    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
-    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic), detect_batch_type_task_id)
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants), detect_batch_type_task_id)
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences), detect_batch_type_task_id)
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene), detect_batch_type_task_id)
 
     snv_somatic >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
+++ b/dags/lib/groups/normalize/normalize_somatic_tumor_only.py
@@ -14,13 +14,14 @@ def normalize_somatic_tumor_only(
         skip_consequences: str,
         skip_coverage_by_gene: str,
         spark_jar: str,
+        detect_batch_type_task_id: str = None,
 ):
     target_batch_types = [ClinAnalysis.SOMATIC_TUMOR_ONLY]
 
-    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic))
-    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only))
-    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants))
-    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences))
-    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene))
+    snv_somatic = normalize.snv_somatic(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_snv_somatic), detect_batch_type_task_id)
+    cnv_somatic_tumor_only = normalize.cnv_somatic_tumor_only(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_cnv_somatic_tumor_only), detect_batch_type_task_id)
+    variants = normalize.variants(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_variants), detect_batch_type_task_id)
+    consequences = normalize.consequences(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_consequences), detect_batch_type_task_id)
+    coverage_by_gene = normalize.coverage_by_gene(batch_id, analysis_ids, target_batch_types, spark_jar, skip(skip_all, skip_coverage_by_gene), detect_batch_type_task_id)
 
     snv_somatic >> cnv_somatic_tumor_only >> variants >> consequences >> coverage_by_gene

--- a/dags/lib/tasks/normalize.py
+++ b/dags/lib/tasks/normalize.py
@@ -6,7 +6,7 @@ from lib.utils_etl import ClinAnalysis
 NORMALIZED_MAIN_CLASS = 'bio.ferlab.clin.etl.normalized.RunNormalized'
 
 
-def snv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def snv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv',
         task_id='snv',
@@ -19,11 +19,12 @@ def snv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def snv_somatic(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def snv_somatic(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='snv_somatic',
         task_id='snv_somatic',
@@ -36,11 +37,12 @@ def snv_somatic(batch_id: str, analysis_ids: list, target_batch_types: List[Clin
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv',
         task_id='cnv',
@@ -53,11 +55,12 @@ def cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def cnv_somatic_tumor_only(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def cnv_somatic_tumor_only(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='cnv_somatic_tumor_only',
         task_id='cnv_somatic_tumor_only',
@@ -70,11 +73,12 @@ def cnv_somatic_tumor_only(batch_id: str, analysis_ids: list, target_batch_types
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def variants(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def variants(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='variants',
         task_id='variants',
@@ -87,11 +91,12 @@ def variants(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAna
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def consequences(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def consequences(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='consequences',
         task_id='consequences',
@@ -104,11 +109,12 @@ def consequences(batch_id: str, analysis_ids: list, target_batch_types: List[Cli
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def coverage_by_gene(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def coverage_by_gene(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='coverage_by_gene',
         task_id='coverage_by_gene',
@@ -121,11 +127,12 @@ def coverage_by_gene(batch_id: str, analysis_ids: list, target_batch_types: List
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
 
-def exomiser(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def exomiser(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='exomiser',
         task_id='exomiser',
@@ -138,10 +145,11 @@ def exomiser(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAna
         skip=skip,
         batch_id=batch_id,
         analysis_ids=analysis_ids,
-        target_batch_types=target_batch_types
+        target_batch_types=target_batch_types,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
-def exomiser_cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def exomiser_cnv(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='exomiser_cnv',
         task_id='exomiser_cnv',
@@ -155,10 +163,11 @@ def exomiser_cnv(batch_id: str, analysis_ids: list, target_batch_types: List[Cli
         batch_id=batch_id,
         analysis_ids=analysis_ids,
         target_batch_types=target_batch_types,
-        batch_id_deprecated=True
+        batch_id_deprecated=True,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )
 
-def franklin(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str) -> SparkETLOperator:
+def franklin(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAnalysis], spark_jar: str, skip: str, detect_batch_type_task_id: str) -> SparkETLOperator:
     return SparkETLOperator(
         entrypoint='franklin',
         task_id='franklin',
@@ -172,5 +181,6 @@ def franklin(batch_id: str, analysis_ids: list, target_batch_types: List[ClinAna
         batch_id=batch_id,
         analysis_ids=analysis_ids,
         target_batch_types=target_batch_types,
-        batch_id_deprecated=True
+        batch_id_deprecated=True,
+        detect_batch_type_task_id=detect_batch_type_task_id,
     )


### PR DESCRIPTION
**etl_migrate** (my dear dag)

- [x] add a new `etl_migrate_batch` DAG that do the same but for a `batch_id`
- [x] add batch_ids distinct list extraction from clinical or from config if defined (will be important for QA with the silly data)
- [x] update `etl_migrate` to call `etl_migrate_batch` via trigger dag + expand
- [x] add `detect_batch_type_task_id` param in normalized ETLs (not used for now)