### PR TITLE
feat: CLIN-4799 removed unused task get-all-sequencing-ids in dag etl

### DIFF
--- a/dags/etl_run.py
+++ b/dags/etl_run.py
@@ -1,12 +1,9 @@
 from datetime import datetime
-from typing import List, Set
 
 from airflow import DAG
-from airflow.decorators import task
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
-from lib.datasets import enriched_clinical
 from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.groups.nextflow.nextflow_germline import nextflow_germline
 from lib.operators.trigger_dagrun import TriggerDagRunOperator
@@ -19,7 +16,6 @@ from lib.utils_etl import (
     ClinAnalysis, color,
     get_germline_analysis_ids, get_ingest_dag_configs_by_analysis_ids,
     spark_jar)
-from pandas import DataFrame
 
 with DAG(
         dag_id='etl_run',
@@ -57,37 +53,7 @@ with DAG(
         spark_jar=spark_jar()
     )
 
-    @task.virtualenv(task_id='get_all_sequencing_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical], max_active_tis_per_dag=1)
-    def get_all_sequencing_ids(sequencing_ids: List[str]) -> Set[str]:
-        """
-        Retrieves all sequencing IDs that share the same analysis ID as the given sequencing IDs from the
-        `enriched_clinical` Delta table. Validates that all sequencing IDs have at least one associated SNV VCF file and
-        that all proband sequencing IDs have at least one associated clinical sign.
-        """
-        import logging
-
-        from airflow.exceptions import AirflowFailException
-        from lib.datasets import enriched_clinical
-        from lib.utils_etl_tables import get_analysis_ids, to_pandas
-
-        distinct_sequencing_ids: Set[str] = set(sequencing_ids)
-        logging.info(f"Distinct input sequencing IDs: {distinct_sequencing_ids}")
-
-        df: DataFrame = to_pandas(enriched_clinical.uri)
-        clinical_df = df[["sequencing_id", "analysis_id", "is_proband", "clinical_signs", "snv_vcf_germline_urls", "batch_id"]]
-
-        # Get all sequencing IDs that share the same analysis ID as the given sequencing IDs
-        analysis_ids = get_analysis_ids(clinical_df, sequencing_ids=distinct_sequencing_ids)
-        _all_sequencing_ids = set(clinical_df.loc[clinical_df["analysis_id"].isin(analysis_ids), "sequencing_id"])
-        if not _all_sequencing_ids:
-            raise AirflowFailException("No sequencing IDs found for the given input sequencing IDs")
-        logging.info(f"Analysis IDs associated with input sequencing IDs: {analysis_ids}")
-        logging.info(f"All sequencing IDs associated with input sequencing IDs: {_all_sequencing_ids}")
-
-        return _all_sequencing_ids
-
     get_sequencing_ids_task = get_sequencing_ids()
-    get_all_sequencing_ids_task = get_all_sequencing_ids(get_sequencing_ids_task)
     get_all_analysis_ids_task = get_all_analysis_ids(sequencing_ids=get_sequencing_ids_task)
 
     detect_batch_types_task = batch_type.detect(analysis_ids=get_all_analysis_ids_task, allowMultipleIdentifierTypes=True)
@@ -111,7 +77,7 @@ with DAG(
     (
         start >> params_validate >>
         ingest_fhir_group >>
-        get_sequencing_ids_task >> get_all_sequencing_ids_task >> get_all_analysis_ids_task >>
+        get_sequencing_ids_task >> get_all_analysis_ids_task >>
         detect_batch_types_task >>
         get_germline_analysis_ids_task >> nextflow_germline_task_group >>
         get_ingest_dag_configs_by_analysis_ids_task >> trigger_ingest_by_sequencing_ids_dags >>


### PR DESCRIPTION
In this PR, we remove the get-all-sequencing-ids-task from the etl_run DAG.

We identified that, after the recent CLIN-4799 refactoring,  it is no longer used and unnecessarily slows down the DAG execution.

**Tests**
Tested locally (pointing on QA) with a valid germline sequencing id to make sure to pass in all the dag steps. Everything looks good.