### PR TITLE
Fix/clin 5015 etl ingest dag fail on somatic analysis

### DIFF
--- a/dags/lib/groups/ingest/ingest_germline.py
+++ b/dags/lib/groups/ingest/ingest_germline.py
@@ -1,8 +1,8 @@
-from airflow.decorators import task, task_group
+from airflow.decorators import task_group
 from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.groups.normalize.normalize_germline import normalize_germline
 from lib.tasks import batch_type, clinical
-from lib.utils_etl import ClinAnalysis
+from lib.utils_etl import BioinfoAnalysisCode, ClinAnalysis
 
 
 @task_group(group_id='ingest_germline')
@@ -43,7 +43,7 @@ def ingest_germline(
     )
 
     get_all_analysis_ids = clinical.get_all_analysis_ids(analysis_ids=analysis_ids, batch_id=batch_id, skip=skip_all)
-    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
+    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(bioinfo_analysis_code=BioinfoAnalysisCode.GEBA, analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
 
     normalize_germline_group = normalize_germline(
         batch_id=get_analysis_ids_related_batch_task,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_normal.py
@@ -3,7 +3,7 @@ from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.groups.normalize.normalize_somatic_tumor_normal import \
     normalize_somatic_tumor_normal
 from lib.tasks import batch_type, clinical
-from lib.utils_etl import ClinAnalysis
+from lib.utils_etl import BioinfoAnalysisCode, ClinAnalysis
 
 
 @task_group(group_id='ingest_somatic_tumor_normal')
@@ -40,7 +40,7 @@ def ingest_somatic_tumor_normal(
     )
 
     get_all_analysis_ids = clinical.get_all_analysis_ids(analysis_ids=analysis_ids, batch_id=batch_id, skip=skip_all)
-    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
+    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(bioinfo_analysis_code=BioinfoAnalysisCode.TNEBA, analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
 
     normalize_somatic_tumor_normal_group = normalize_somatic_tumor_normal(
         batch_id=get_analysis_ids_related_batch_task,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
@@ -43,7 +43,7 @@ def ingest_somatic_tumor_only(
     get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(bioinfo_analysis_code=BioinfoAnalysisCode.TEBA, analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
-        batch_id=batch_id,
+        batch_id=get_analysis_ids_related_batch_task,
         analysis_ids=analysis_ids,
         skip_all=skip_all,
         skip_snv_somatic=skip_snv_somatic,

--- a/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
+++ b/dags/lib/groups/ingest/ingest_somatic_tumor_only.py
@@ -3,7 +3,7 @@ from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.groups.normalize.normalize_somatic_tumor_only import \
     normalize_somatic_tumor_only
 from lib.tasks import batch_type, clinical
-from lib.utils_etl import ClinAnalysis
+from lib.utils_etl import BioinfoAnalysisCode, ClinAnalysis
 
 
 @task_group(group_id='ingest_somatic_tumor_only')
@@ -40,7 +40,7 @@ def ingest_somatic_tumor_only(
     )
 
     get_all_analysis_ids = clinical.get_all_analysis_ids(analysis_ids=analysis_ids, batch_id=batch_id, skip=skip_all)
-    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
+    get_analysis_ids_related_batch_task = clinical.get_analysis_ids_related_batch(bioinfo_analysis_code=BioinfoAnalysisCode.TEBA, analysis_ids=get_all_analysis_ids, batch_id=batch_id, skip=skip_all)
 
     normalize_somatic_tumor_only_group = normalize_somatic_tumor_only(
         batch_id=batch_id,

--- a/dags/lib/tasks/clinical.py
+++ b/dags/lib/tasks/clinical.py
@@ -2,21 +2,26 @@ from typing import List, Optional, Set
 
 from airflow.decorators import task
 from lib.datasets import enriched_clinical
+from lib.utils import SKIP_EXIT_CODE
+from lib.utils_etl import BioinfoAnalysisCode
+
 from pandas import DataFrame
 
 
-@task.virtualenv(task_id='get_all_analysis_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+@task.virtualenv(skip_on_exit_code=SKIP_EXIT_CODE, task_id='get_all_analysis_ids', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
 def get_all_analysis_ids(analysis_ids: Optional[Set[str]] = None, sequencing_ids: Optional[Set[str]] = None, batch_ids: Optional[Set[str]] = None, batch_id: Optional[str] = None, skip: bool = False) -> List[str]:
-    
-    if skip:
-        return []
-    
+
     """
     Retrieves all analysis IDs for every sequencing IDs
     """
+    import sys
     from airflow.exceptions import AirflowFailException
     from lib.datasets import enriched_clinical
+    from lib.utils import SKIP_EXIT_CODE
     from lib.utils_etl_tables import get_analysis_ids, to_pandas
+
+    if skip:
+        sys.exit(SKIP_EXIT_CODE)
 
     batch_ids = batch_ids if batch_ids else [batch_id] if batch_id and batch_id != "" else []
 
@@ -29,34 +34,37 @@ def get_all_analysis_ids(analysis_ids: Optional[Set[str]] = None, sequencing_ids
 
     return all_analysis_ids
 
-@task.virtualenv(task_id='get_analysis_ids_related_batch', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
-def get_analysis_ids_related_batch(analysis_ids: Optional[Set[str]], batch_id: str, skip: bool = False) -> str:
+
+@task.virtualenv(skip_on_exit_code=SKIP_EXIT_CODE, task_id='get_analysis_ids_related_batch', requirements=["deltalake===0.24.0"], inlets=[enriched_clinical])
+def get_analysis_ids_related_batch(analysis_ids: Optional[Set[str]], batch_id: str, bioinfo_analysis_code: BioinfoAnalysisCode, skip: bool = False) -> str:
 
     '''
     Utils function to revert to Batch ID a list of analysis IDs provided to a DAG as param.
     Will probably be mostly used in etl_ingest as long as we have ETLs using batch_id as input.
     '''
-    
+
     if batch_id and len(batch_id) > 0:
         return batch_id
-    
-    if skip:
-        return ""
-    
-    if not analysis_ids or len(analysis_ids) == 0:
-        raise AirflowFailException(f"No batch ID or analysis IDs were provided.")
-    
+
+    import sys
     from airflow.exceptions import AirflowFailException
     from lib.datasets import enriched_clinical
+    from lib.utils import SKIP_EXIT_CODE
     from lib.utils_etl_tables import get_batch_ids, to_pandas
 
+    if skip:
+        sys.exit(SKIP_EXIT_CODE)
+
+    if not analysis_ids or len(analysis_ids) == 0:
+        raise AirflowFailException("No batch ID or analysis IDs were provided.")
+
     df: DataFrame = to_pandas(enriched_clinical.uri)
-    clinical_df = df[["analysis_id", "sequencing_id", "batch_id"]]
-    all_batch_ids = sorted(get_batch_ids(clinical_df, analysis_ids=analysis_ids))
+    clinical_df = df[["analysis_id", "sequencing_id", "batch_id", "bioinfo_analysis_code"]]
+    all_batch_ids = sorted(get_batch_ids(clinical_df, bioinfo_analysis_code=bioinfo_analysis_code, analysis_ids=analysis_ids))
 
     if not all_batch_ids or len(all_batch_ids) == 0:
         raise AirflowFailException(f"No batch IDs found for the provided analysis IDs ({analysis_ids}).")
-    
+
     if len(all_batch_ids) > 1:
         raise AirflowFailException(f"Analysis IDs belong to more than one batch ID ({all_batch_ids}).")
 

--- a/dags/lib/utils_etl_tables.py
+++ b/dags/lib/utils_etl_tables.py
@@ -1,5 +1,7 @@
 from typing import Collection, Optional, Set
 
+from lib.utils_etl import BioinfoAnalysisCode
+
 from pandas import DataFrame
 
 
@@ -38,7 +40,8 @@ def get_analysis_ids(clinical_df: DataFrame, analysis_ids: Optional[Collection[s
         ]
     )
 
-def get_batch_ids(clinical_df: DataFrame, analysis_ids: Optional[Collection[str]] = None, sequencing_ids: Optional[Collection[str]] = None) -> Set[str]:
+
+def get_batch_ids(clinical_df: DataFrame, bioinfo_analysis_code: BioinfoAnalysisCode, analysis_ids: Optional[Collection[str]] = None, sequencing_ids: Optional[Collection[str]] = None) -> Set[str]:
     """
         Return the set of batch ids corresponding to the provided sequencing ids or analysis ids from the
         enriched_clinical table.
@@ -51,7 +54,7 @@ def get_batch_ids(clinical_df: DataFrame, analysis_ids: Optional[Collection[str]
 
     return set(
         clinical_df.loc[
-            clinical_df["analysis_id"].isin(analysis_ids) | clinical_df["sequencing_id"].isin(sequencing_ids),
+            (clinical_df["bioinfo_analysis_code"] == bioinfo_analysis_code.value) & (clinical_df["analysis_id"].isin(analysis_ids) | clinical_df["sequencing_id"].isin(sequencing_ids)),
             "batch_id"
         ]
     )

--- a/tests/lib/test_utils_etl_tables.py
+++ b/tests/lib/test_utils_etl_tables.py
@@ -1,32 +1,69 @@
 import pandas as pd
 import pytest
 
-from dags.lib.utils_etl_tables import get_analysis_ids
-
 
 @pytest.fixture
 def clinical_df():
     return pd.DataFrame([
-        {'sequencing_id': 'SRS0001', 'batch_id': 'BAT1', 'analysis_id': 'SRA0001'},
-        {'sequencing_id': 'SRS0002', 'batch_id': 'BAT2', 'analysis_id': 'SRA0001'},
-        {'sequencing_id': 'SRS0003', 'batch_id': 'BAT2', 'analysis_id': 'SRA0002'},
-        {'sequencing_id': 'SRS0004', 'batch_id': 'BAT3', 'analysis_id': 'SRA0003'},
+        {'sequencing_id': 'SRS0001', 'batch_id': 'BAT1', 'analysis_id': 'SRA0001', 'bioinfo_analysis_code': 'TNEBA'},
+        {'sequencing_id': 'SRS0002', 'batch_id': 'BAT2', 'analysis_id': 'SRA0001', 'bioinfo_analysis_code': 'TEBA'},
+        {'sequencing_id': 'SRS0003', 'batch_id': 'BAT2', 'analysis_id': 'SRA0002', 'bioinfo_analysis_code': 'TEBA'},
+        {'sequencing_id': 'SRS0004', 'batch_id': 'BAT3', 'analysis_id': 'SRA0003', 'bioinfo_analysis_code': 'GEBA'},
+        {'sequencing_id': 'SRS0005', 'batch_id': 'BAT4', 'analysis_id': 'SRA0004', 'bioinfo_analysis_code': 'GEBA'},
     ])
 
 
 def test_get_analysis_ids_from_sequencing_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_analysis_ids
     analysis_ids = get_analysis_ids(clinical_df, sequencing_ids=['SRS0001', 'SRS0003'])
 
     assert analysis_ids == {'SRA0001', 'SRA0002'}
 
 
 def test_get_analysis_ids_from_batch_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_analysis_ids
     analysis_ids = get_analysis_ids(clinical_df, batch_ids=['BAT1', 'BAT3'])
 
     assert analysis_ids == {'SRA0001', 'SRA0003'}
 
 
 def test_get_analysis_ids_from_sequencing_ids_and_batch_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_analysis_ids
     analysis_ids = get_analysis_ids(clinical_df, sequencing_ids=['SRS0001', 'SRS0004'], batch_ids=['BAT2'])
 
     assert analysis_ids == {'SRA0001', 'SRA0002', 'SRA0003'}
+
+
+def test_get_batch_ids_from_analysis_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_batch_ids
+    from dags.lib.utils_etl import BioinfoAnalysisCode
+    batch_ids = get_batch_ids(clinical_df, bioinfo_analysis_code=BioinfoAnalysisCode.GEBA, analysis_ids=['SRA0003', 'SRA0004'])
+    assert batch_ids == {'BAT3', 'BAT4'}
+
+
+def test_get_batch_ids_from_sequencing_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_batch_ids
+    from dags.lib.utils_etl import BioinfoAnalysisCode
+    batch_ids = get_batch_ids(clinical_df, bioinfo_analysis_code=BioinfoAnalysisCode.GEBA, sequencing_ids=['SRS0004', 'SRS0005'])
+    assert batch_ids == {'BAT3', 'BAT4'}
+
+
+def test_get_batch_ids_from_sequencing_ids_and_analysis_ids(clinical_df):
+    from dags.lib.utils_etl_tables import get_batch_ids
+    from dags.lib.utils_etl import BioinfoAnalysisCode
+    batch_ids = get_batch_ids(clinical_df, bioinfo_analysis_code=BioinfoAnalysisCode.GEBA, sequencing_ids=['SRS0004'], analysis_ids=['SRA0004'])
+    assert batch_ids == {'BAT3', 'BAT4'}
+
+
+def test_get_batch_ids_from_analysis_id_in_both_tumor_only_and_tumor_normal_batches(clinical_df):
+    from dags.lib.utils_etl_tables import get_batch_ids
+    from dags.lib.utils_etl import BioinfoAnalysisCode
+    batch_ids = get_batch_ids(clinical_df, bioinfo_analysis_code=BioinfoAnalysisCode.TEBA, analysis_ids=['SRA0001'])
+    assert batch_ids == {'BAT2'}
+
+
+def test_get_batch_ids_with_no_match(clinical_df):
+    from dags.lib.utils_etl_tables import get_batch_ids
+    from dags.lib.utils_etl import BioinfoAnalysisCode
+    batch_ids = get_batch_ids(clinical_df, bioinfo_analysis_code=BioinfoAnalysisCode.GEBA, analysis_ids=['SRA0001'])
+    assert batch_ids == set()


### PR DESCRIPTION
Le dag etl_ingest échoue quand on l'éxécute avec un analysis_id somatique. Ce pull request vise à régler les problèmes pour qu'il puisse être exécuté avec succès quand il est appelé avec le analysis_id à partir de etl_run.py.

## Changements

Il y a 2 commits qui corrigent chacun un problème séparé:

**Commit 1:  Gestion des cas multi-batchs pour un même analysis_id**
La logique d’inférence du batch échouait lorsque le même analysis_id était présent dans plusieurs batchs, ce qui est un cas valide (par exemple, lorsqu’on a une analyse TEBA et TNEBA en même temps).
J’ai modifié la logique pour qu’elle tienne compte du bioinfo_analysis_code lors de l’inférence du batch, afin de bien gérer ces situations.

**Commit 2:  Batch_id non transmis correctement (somatic tumor only)**
Pour les analyses de type "somatic tumor only", une tâche permet d’inférer le batch_id à partir du analysis_id, mais ce batch_id inféré n’était pas transmis aux tâches suivantes.   J'ai corrigé pour que le batch_id inféré soit transmis aux tâches concernées, comme c'est déjà fait pour les cas germline et somatic_tumor_normal.

## Tests

Tests effectués en local en pointant sur QA:
-  Analysis id dans batchs somatic_tumor_only et somatic_tumor_normal: ✅ 
L'analysis id est correctement associé à la batch somatic tumor only. La batch en question est ré-ingérée avec succès
Les données de la batch somatic_tumor_normal, elles, ne sont pas ré-ingérées, ce qui est le comportement normal, car on ne supporte pas encore ces batch pour les analysis_id.
- Analysis id dans somatic_tumor_only seulement ✅

Quelques tests unitaires ont été ajoutés pour la logique qui infère le batch_id