### PR TITLE
fix: CLIN-5123 call exomiser cnv only on proband vcf

### DIFF
--- a/dags/lib/tasks/nextflow/cnv_post_processing.py
+++ b/dags/lib/tasks/nextflow/cnv_post_processing.py
@@ -58,7 +58,7 @@ def prepare(analysis_id_pheno_file_mapping: Dict[str, str], job_hash: str, skip:
         'cnv_vcf_germline_urls': 'vcf'
     }
 
-    samples = df[df['analysis_id'].isin(analysis_id_pheno_file_mapping.keys())] \
+    samples = df[df['analysis_id'].isin(analysis_id_pheno_file_mapping.keys()) & df["is_proband"]] \
         .rename(columns=column_map)[[*column_map.values()]]
 
     # Replace sequencing strategy with 'WES' because Nextflow expects 'WES' instead of 'WXS'


### PR DESCRIPTION
Pour fixer https://ferlab-crsj.atlassian.net/browse/CLIN-5123


En ce moment, on inclut tous les membres de l’analyse dans le samplesheet.
C’est correct pour le pipeline de postprocessing SNV, qui sait combiner les VCFs individuels en un VCF multisample avant de lancer Exomiser.

Mais pour le CNV-post-processing, ce n’est pas géré : il ne supporte que le proband, donc il devrait y avoir une seule ligne par analyse dans le samplesheet.


Test: 
J'ai testé en local en pointant sur QA. Pour l'instant, je ne peux pas tester le cas multi-sample en QA malheureusement.