### PR TITLE
feat CLIN-4902: Schedule DAG and update code to new file an url

### DIFF
--- a/dags/lib/config.py
+++ b/dags/lib/config.py
@@ -45,7 +45,6 @@ slack_hook_url = Variable.get('slack_hook_url', None)
 show_test_dags = Variable.get('show_test_dags', None) == 'yes'
 cosmic_credentials = Variable.get('cosmic_credentials', None)
 omim_credentials = Variable.get('omim_credentials', None)
-topmed_bravo_credentials = Variable.get('topmed_bravo_credentials', None)
 basespace_illumina_credentials = Variable.get('basespace_illumina_credentials', None)
 svclustering_batch_size = Variable.get('svclustering_batch_size', '100')
 dev_skip_task = Variable.get('dev_skip_task', None) == 'yes'

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -80,7 +80,6 @@ def get_index_of_alias(alias_name: str):
 
     return index_name
 
-
 def get_color(index_name: str):
     if "blue" in index_name:
         return 'blue'

--- a/dags/lib/utils_s3.py
+++ b/dags/lib/utils_s3.py
@@ -40,14 +40,14 @@ def stream_upload_to_s3(s3: S3Hook, s3_bucket: str, s3_key: str, url: str, heade
         s3.load_file_obj(response.raw, s3_key, s3_bucket, replace)
 
 
-def stream_upload_or_resume_to_s3(s3: S3Hook, s3_bucket: str, s3_key: str, url: str, partSizeMb: int = 200, md5: str = None) -> None:
+def stream_upload_or_resume_to_s3(s3: S3Hook, s3_bucket: str, s3_key: str, url: str, headers: Any = None, partSizeMb: int = 200, md5: str = None) -> None:
     try:
         s3_client = s3.get_conn()
         parts = []
         part_number = 1
         file_size=0
         uploaded_bytes=0
-        headers = {}
+        headers = headers or {}
 
         # Check if an UploadId already exists to resume download
         upload_id = get_s3_multipart_upload_id(s3, s3_bucket, s3_key)


### PR DESCRIPTION
Pour récupérer les fichiers, il faut se connecter avec un compte Google sur le site, récupérer le cookie puis le donner en entré au DAG. Avant ce paramètre était rentré dans Vault puis utilisé par le DAG, cependant comme ce cookie semble changer régulièrement et qu'on en a besoin seulement au moment de l'exécution, j'ai choisi de supprimer le paramètre de la config pour le mettre en paramètre du DAG à fournir au moment de l'exécution.

Le DAG doit être exécuté tous les 3 mois. Comme cela nécessite une opération manuelle, il faudrait un rappel au 3 mois. J'ai mis un Schedule pour que le DAG se lance au 3 mois. Il sera en échec ce qui nous donnerais une sorte d'alerte. Est-ce que ca parait suffisant ou alors, il serait mieux d'enlever le schedule et de trouver une autre façon de faire ?

La version ne peut être récupérée du site dorénavant. Le site est généré via JS lors du rendu, donc le contenu est inaccessible par une requête get HTTP, sinon il faudrait passer par un lib capable de gérer le rendu JS (je pense qu'on veut éviter ca). Du coup la version devient un paramètre en entrée du DAG. Ca vous semble ok ? 