### PR TITLE
feat: CLIN-5861 - force merge ES indexes post release

### DIFF
--- a/dags/etl.py
+++ b/dags/etl.py
@@ -25,7 +25,8 @@ from lib.tasks.params_validate import validate_color, prepare_analysis_ids_arg, 
 from lib.utils_etl import (ClinAnalysis, color, default_or_initial,
                            get_ingest_dag_config_by_batch_group,
                            get_ingest_dag_configs_by_batch_id, release_id,
-                           skip_if_param_empty, skip_notify, spark_jar)
+                           skip_es_post_release, skip_if_param_empty,
+                           skip_notify, spark_jar)
 
 with DAG(
         dag_id='etl',
@@ -46,6 +47,7 @@ with DAG(
             'notify': Param('no', enum=['yes', 'no']),
             'qc': Param('yes', enum=['yes', 'no']),
             'rolling': Param('yes' if env == Env.QA else 'no', enum=['yes', 'no']),
+            'es_post_release': Param('yes', enum=['yes', 'no']),
             'spark_jar': Param('', type=['null', 'string']),
         },
         default_args={
@@ -295,6 +297,17 @@ with DAG(
                                                                  ClinAnalysis.SOMATIC_TUMOR_ONLY]) + skip_if_cnv_frequencies()
     )
 
+    trigger_post_release = TriggerDagRunOperator(
+        task_id='post_release',
+        trigger_dag_id='etl_post_release',
+        wait_for_completion=True,
+        skip=skip_es_post_release(),
+        conf={
+            'release_id': release_id(),
+            'color': env_color,
+        }
+    )
+
     publish_group = publish_index(
         color=underscore_color,
         spark_jar=spark_jar(),
@@ -414,7 +427,7 @@ with DAG(
      get_ingest_dag_configs_by_batch_id_task >> group_analysis_ids_by_batch_task >> get_ingest_dag_configs_by_analysis_ids_task >>
      trigger_ingest_by_batch_id_dags >> trigger_ingest_by_analysis_ids_dags >> ingest_complete >>
      enrich_group() >> prepare_group >> qa_group >> get_release_ids_group >>
-     delete_previous_variant_centric_group() >> index_group >>
+     delete_previous_variant_centric_group() >> index_group >> trigger_post_release >>
      publish_group >> trigger_rolling_dag >> trigger_delete_previous_releases >> trigger_cnv_frequencies >>
      notify_batch_ids_task >> prepare_notify_analysis_ids_task >> prepare_analysis_ids_arg_task >> update_analysis_status_task >> notify_analysis_ids_task >> slack >> trigger_qc_es_dag >> trigger_qc_dag)
 

--- a/dags/etl_cnv_frequencies.py
+++ b/dags/etl_cnv_frequencies.py
@@ -14,10 +14,10 @@ from lib.doc import cnv_frequencies as doc
 from lib.groups.ingest.ingest_fhir import ingest_fhir
 from lib.operators.trigger_dagrun import TriggerDagRunOperator
 from lib.slack import Slack
-from lib.tasks import (enrich, es, index, params_validate, prepare_index,
+from lib.tasks import (enrich, es, es_optimize, index, params_validate, prepare_index,
                        publish_index, qa)
 from lib.tasks.nextflow import svclustering
-from lib.utils_etl import color, release_id, spark_jar
+from lib.utils_etl import color, release_id, skip_es_post_release, spark_jar
 
 with DAG(
         dag_id='etl_cnv_frequencies',
@@ -28,6 +28,7 @@ with DAG(
             'release_id': Param('', type=['null', 'string']),
             'color': Param('', type=['null', 'string']),
             'spark_jar': Param('', type=['null', 'string']),
+            'es_post_release': Param('yes', enum=['yes', 'no']),
         },
         default_args={
             'trigger_rule': TriggerRule.NONE_FAILED,
@@ -104,6 +105,13 @@ with DAG(
     publish_cnv_centric_task = publish_index.cnv_centric(release_id, color('_'), spark_jar(),
                                                          task_id='publish_cnv_centric',
                                                          on_success_callback=Slack.notify_dag_completion)
+    wait_for_ready_cnv = es_optimize.wait_for_ready.override(task_id='wait_for_ready_cnv_centric')(
+        index_name='cnv_centric', release_id=release_id, color=color('_'), skip=skip_es_post_release()
+    )
+    force_merge_cnv = es_optimize.force_merge.override(task_id='force_merge_cnv_centric')(
+        index_name='cnv_centric', release_id=release_id, color=color('_'), skip=skip_es_post_release()
+    )
+
     delete_previous_release_task = es.delete_previous_release('cnv_centric', release_id, color('_'))
 
     trigger_rolling_dag = TriggerDagRunOperator(
@@ -117,5 +125,5 @@ with DAG(
     )
 
     (params_validate_task >> ingest_fhir_group >> prepare_svclustering_task >> run_group() >> normalize_group() >>
-     enrich_cnv_task >> prepare_cnv_centric_task >> qa_group() >> index_cnv_centric_task >> publish_cnv_centric_task >>
+     enrich_cnv_task >> prepare_cnv_centric_task >> qa_group() >> index_cnv_centric_task >> wait_for_ready_cnv >> force_merge_cnv >> publish_cnv_centric_task >>
      trigger_rolling_dag >> delete_previous_release_task)

--- a/dags/etl_post_release.py
+++ b/dags/etl_post_release.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.trigger_rule import TriggerRule
+
+from lib.groups.index.get_release_ids import get_release_ids
+from lib.groups.index.optimize_indices import optimize_indices
+from lib.slack import Slack
+from lib.tasks.params_validate import validate_color
+from lib.utils_etl import color, release_id
+
+with DAG(
+        dag_id='etl_post_release',
+        start_date=datetime(2022, 1, 1),
+        schedule=None,
+        params={
+            'release_id': Param('', type=['null', 'string']),
+            'color': Param('', type=['null', 'string']),
+        },
+        default_args={
+            'trigger_rule': TriggerRule.NONE_FAILED,
+            'on_failure_callback': Slack.notify_task_failure,
+        },
+        max_active_tasks=6,
+        max_active_runs=1,
+) as dag:
+
+    params_validate = validate_color(color())
+
+    get_release_ids_group = get_release_ids(
+        release_id=release_id(),
+        color=color('_'),
+        increment_release_id=False,
+    )
+
+    optimize = optimize_indices(
+        gene_centric_release_id=release_id('gene_centric'),
+        gene_suggestions_release_id=release_id('gene_suggestions'),
+        variant_centric_release_id=release_id('variant_centric'),
+        variant_suggestions_release_id=release_id('variant_suggestions'),
+        coverage_by_gene_centric_release_id=release_id('coverage_by_gene_centric'),
+        cnv_centric_release_id=release_id('cnv_centric'),
+        color=color('_'),
+    )
+
+    slack = EmptyOperator(
+        task_id="slack",
+        on_success_callback=Slack.notify_dag_completion
+    )
+
+    params_validate >> get_release_ids_group >> optimize >> slack

--- a/dags/lib/groups/index/optimize_indices.py
+++ b/dags/lib/groups/index/optimize_indices.py
@@ -1,0 +1,32 @@
+from airflow.decorators import task_group
+from lib.tasks import es_optimize
+
+
+@task_group(group_id='optimize_indices')
+def optimize_indices(
+        gene_centric_release_id: str,
+        gene_suggestions_release_id: str,
+        variant_centric_release_id: str,
+        variant_suggestions_release_id: str,
+        cnv_centric_release_id: str,
+        coverage_by_gene_centric_release_id: str,
+        color: str,
+        skip: str = ''
+):
+    indices = {
+        'gene_centric': gene_centric_release_id,
+        'gene_suggestions': gene_suggestions_release_id,
+        'variant_centric': variant_centric_release_id,
+        'variant_suggestions': variant_suggestions_release_id,
+        'cnv_centric': cnv_centric_release_id,
+        'coverage_by_gene_centric': coverage_by_gene_centric_release_id,
+    }
+
+    for name, rid in indices.items():
+        wfg = es_optimize.wait_for_ready.override(task_id=f'wait_for_ready_{name}')(
+            index_name=name, release_id=rid, color=color, skip=skip
+        )
+        fm = es_optimize.force_merge.override(task_id=f'force_merge_{name}')(
+            index_name=name, release_id=rid, color=color, skip=skip
+        )
+        wfg >> fm

--- a/dags/lib/tasks/es_optimize.py
+++ b/dags/lib/tasks/es_optimize.py
@@ -1,0 +1,51 @@
+import logging
+
+import requests
+from airflow.decorators import task
+from airflow.exceptions import AirflowFailException, AirflowSkipException
+from lib.config import env, es_url
+
+
+@task(task_id='wait_for_ready')
+def wait_for_ready(index_name: str, release_id: str, color: str, skip=None, timeout: str = '30m'):
+    """Wait for index to reach green health (all replicas STARTED)."""
+    if skip:
+        raise AirflowSkipException()
+
+    full_index = f'clin_{env}{color}_{index_name}_{release_id}'
+    url = f'{es_url}/_cluster/health/{full_index}?wait_for_status=green&wait_for_no_relocating_shards=true&timeout={timeout}'
+
+    logging.info(f'Waiting for ready status on index [{full_index}] (timeout={timeout})')
+    response = requests.get(url, verify=False)
+    logging.info(f'ES response: {response.text}')
+
+    if not response.ok:
+        raise AirflowFailException(f'Cluster health check failed for {full_index}: {response.text}')
+
+    result = response.json()
+    if result.get('timed_out', False) or result.get('status') != 'green':
+        raise AirflowFailException(
+            f'Index {full_index} did not reach green within {timeout} '
+            f'(status={result.get("status")}, timed_out={result.get("timed_out")})'
+        )
+
+    logging.info(f'Index [{full_index}] is green')
+
+
+@task(task_id='force_merge')
+def force_merge(index_name: str, release_id: str, color: str, skip=None, max_num_segments: int = 1, timeout: int = 3600):
+    """Trigger force merge. Best-effort: logs warning on timeout (merge continues on ES)."""
+    if skip:
+        raise AirflowSkipException()
+
+    full_index = f'clin_{env}{color}_{index_name}_{release_id}'
+    url = f'{es_url}/{full_index}/_forcemerge?max_num_segments={max_num_segments}'
+
+    logging.info(f'Triggering force merge on [{full_index}] (max_num_segments={max_num_segments})')
+    try:
+        response = requests.post(url, verify=False, timeout=timeout)
+        logging.info(f'ES response: {response.text}')
+        if not response.ok:
+            logging.warning(f'Force merge returned error for {full_index}: {response.text} (merge may still be running)')
+    except requests.exceptions.Timeout:
+        logging.warning(f'Force merge timed out for {full_index} — merge continues in background on ES')

--- a/dags/lib/tasks/index.py
+++ b/dags/lib/tasks/index.py
@@ -20,6 +20,8 @@ def gene_centric(release_id: str, color: str, spark_jar: str, skip: str = '', ta
             'gene_centric',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )
@@ -43,6 +45,8 @@ def gene_suggestions(release_id: str, color: str, spark_jar: str, skip: str = ''
             'gene_suggestions',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )
@@ -66,6 +70,8 @@ def variant_centric(release_id: str, color: str, spark_jar: str, skip: str = '',
             'variant_centric',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )
@@ -89,6 +95,8 @@ def variant_suggestions(release_id: str, color: str, spark_jar: str, skip: str =
             'variant_suggestions',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )
@@ -112,6 +120,8 @@ def cnv_centric(release_id: str, color: str, spark_jar: str, skip: str = '', tas
             'cnv_centric',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )
@@ -135,6 +145,8 @@ def coverage_by_gene_centric(release_id: str, color: str, spark_jar: str, skip: 
             'coverage_by_gene_centric',
             '1900-01-01 00:00:00',
             f'config/{env}.conf',
+            'true',   # disableReplicas
+            'false',  # forceMerge — handled by etl_post_release DAG
         ],
         **kwargs
     )

--- a/dags/lib/utils_etl.py
+++ b/dags/lib/utils_etl.py
@@ -157,6 +157,10 @@ def skip_if_param_not(param_template, value) -> str:
         '{{', '').replace('}}', '')
 
 
+def skip_es_post_release() -> str:
+    return '{% if params.es_post_release == "yes" %}{% else %}yes{% endif %}'
+
+
 def skip(cond1: str, cond2: str) -> str:
     """
     Skips the task if one of the conditions is True.


### PR DESCRIPTION
<img width="707" height="427" alt="Screenshot from 2026-04-13 21-34-17" src="https://github.com/user-attachments/assets/af0353aa-071a-491c-b68e-b7edb6a4255f" />

Add new dag `etl_post_release` will perform `force merge` of indexes in ES if param isnt skip
In both etl.py and cetl_cnv_frequencies.py
