### PR TITLE
feat: CLIN-5935 Update condition of READY analysis from Franklin

### DIFF
--- a/dags/sensors/franklin.py
+++ b/dags/sensors/franklin.py
@@ -9,9 +9,8 @@ from lib import config
 from lib.config import clin_datalake_bucket
 from lib.franklin import (FranklinStatus, build_s3_analyses_ids_key,
                           extract_from_name_aliquot_id,
-                          extract_param_from_s3_key, get_analysis_status,
-                          get_franklin_token, write_s3_analysis_status, get_s3_analyses_keys,
-                          extract_from_name_analysis_id)
+                          extract_from_name_analysis_id, get_analysis_status,
+                          get_franklin_token, write_s3_analysis_status)
 
 
 class FranklinAPISensor(BaseSensorOperator):
@@ -30,31 +29,24 @@ class FranklinAPISensor(BaseSensorOperator):
 
         analysis_ids = self.analysis_ids
         clin_s3 = S3Hook(config.s3_conn_id)
-        keys = get_s3_analyses_keys(clin_s3, analysis_ids)
 
         created_analyses = []
         ready_analyses = []
 
-        for key in keys:
-            if '_FRANKLIN_STATUS_.txt' in key:
-                key_obj = clin_s3.get_key(key, clin_datalake_bucket)
-                status = FranklinStatus[key_obj.get()['Body'].read().decode('utf-8')]
-                if status is FranklinStatus.CREATED:  # ignore others status
-
-                    logging.info(f'Found CREATED: {key}')
-                    analysis_id = extract_param_from_s3_key(key, 'analysis_id')
-
-                    ids_key = clin_s3.get_key(build_s3_analyses_ids_key(analysis_id), clin_datalake_bucket)
-                    ids = ids_key.get()['Body'].read().decode('utf-8').split(',')
-
-                    created_analyses += ids
+        # _FRANKLIN_IDS_.txt holds every Franklin ID (aliquot + family) for an analysis_id;
+        # scanning per-aliquot _FRANKLIN_STATUS_.txt files would drop family IDs once all aliquots are READY.
+        for analysis_id in analysis_ids:
+            ids_key = build_s3_analyses_ids_key(analysis_id)
+            if clin_s3.check_for_key(ids_key, clin_datalake_bucket):
+                ids = clin_s3.get_key(ids_key, clin_datalake_bucket).get()['Body'].read().decode('utf-8').split(',')
+                created_analyses += ids
 
         # remove duplicated IDs if any
         created_analyses = list(set(created_analyses))
         created_count = len(created_analyses)
 
         if created_count == 0:
-            raise AirflowSkipException('No CREATED analyses')
+            raise AirflowSkipException('No analyses to track')
 
         token = get_franklin_token()
         statuses = get_analysis_status(created_analyses, token)


### PR DESCRIPTION
## Contexte

Ticket : [CLIN-5935](https://ferlab-crsj.atlassian.net/browse/CLIN-5935)

Le `FranklinAPISensor` (`dags/sensors/franklin.py`) abandonnait silencieusement les analyses *family* lorsque tous les aliquots d'un `analysis_id` passaient à `READY` avant la family. Observé en prod le 2026-04-30 sur le run `20260424_LH00336_0405_A23J2KMLT3` — 5 analyses family abandonnées en `CREATING`.

## Avant — pourquoi ça plantait

Le sensor avait deux sources d'information en S3 pour chaque `analysis_id` :

1. **`_FRANKLIN_STATUS_.txt`** — un par couple `(analysis_id, aliquot_id)` :
   - SOLO : 1 fichier (1 aliquot)
   - DUO : 2 fichiers
   - TRIO : 3 fichiers
   - **Aucun fichier pour la family** (l'analyse family n'a pas d'aliquot — `aliquot_id=null`)

2. **`_FRANKLIN_IDS_.txt`** — un seul par `analysis_id`. Contient **tous** les IDs Franklin (aliquots **+** family) en CSV. C'est ce que renvoie l'API Franklin au moment du `POST /analyses/create`.

L'ancien code faisait ceci à chaque poke :

```python
keys = get_s3_analyses_keys(...)        # liste TOUS les fichiers S3 sous analysis_id={X}/...
for key in keys:
    if '_FRANKLIN_STATUS_.txt' in key:           # ne regarde que les status par aliquot
        if status is FranklinStatus.CREATED:     # ne traite que les CREATED
            ids = read('_FRANKLIN_IDS_.txt')     # alors seulement, lit la liste complète
            created_analyses += ids
```

Le bug : **on ne lit `_FRANKLIN_IDS_.txt` que si on tombe sur un `_FRANKLIN_STATUS_.txt` en CREATED**. Or les status passent à `READY` au fur et à mesure que Franklin termine les aliquots, et la family est typiquement plus lente. Donc :

- **t0** : 3 status `CREATED` (aliquots) → on lit `_FRANKLIN_IDS_.txt` → on track 4 IDs (3 aliquots + 1 family)
- **t1** : 1 aliquot devient READY → on a encore 2 status CREATED → on track toujours 4 IDs
- **t2** : tous les aliquots READY → 0 status CREATED → **on ne lit plus `_FRANKLIN_IDS_.txt`** → l'ID family disparaît du tracking
- `created_count == 0` → `raise AirflowSkipException('No CREATED analyses')` alors que la family est encore en `CREATING` côté Franklin

## Après — pourquoi ça marche

Le nouveau code court-circuite la dépendance aux status par aliquot :

```python
for analysis_id in analysis_ids:                           # analysis_ids vient en input du sensor
    ids_key = build_s3_analyses_ids_key(analysis_id)       # raw/landing/franklin/analysis_id={X}/_FRANKLIN_IDS_.txt
    if clin_s3.check_for_key(ids_key, ...):                # défensif : tolère un analysis_id sans Franklin (skip de création)
        ids = read(ids_key).split(',')                     # tous les IDs Franklin (aliquots + family)
        created_analyses += ids
```

On lit **toujours** `_FRANKLIN_IDS_.txt` (la source de vérité), sans condition sur l'état des aliquots. Tant qu'un seul ID Franklin n'est pas READY (aliquot ou family, peu importe), `ready_count != created_count` et le sensor continue à poll.

## La suite du `poke()` n'a pas changé

```python
statuses = get_analysis_status(created_analyses, token)    # appel API Franklin
for status in statuses:
    if status['processing_status'] == 'READY':
        write_s3_analysis_status(... id=franklin_analysis_id)   # écrit _FRANKLIN_STATUS_.txt + _FRANKLIN_ID_.txt
        ready_analyses.append(franklin_analysis_id)
return ready_count == created_count
```

Pour un ID déjà passé READY lors d'un poke précédent, on ré-écrit son `_FRANKLIN_STATUS_.txt` à `READY` et son `_FRANKLIN_ID_.txt` (idempotent) — quelques writes S3 redondants, c'est le seul effet de bord. Les tâches downstream (`download_results`, `clean_up_*`) lisent ces mêmes fichiers donc elles fonctionnent à l'identique.

## Pourquoi c'est facilement réversible

- 1 fichier touché (`dags/sensors/franklin.py`)
- Aucun changement au modèle S3 (`_FRANKLIN_IDS_.txt` existait déjà avec exactement ce contenu — voir `dags/lib/groups/franklin/franklin_create.py:57`)
- Aucun changement aux tâches `franklin_create` / `franklin_update`
- Pour annuler : `git revert` du commit, on retombe sur l'ancien comportement

[CLIN-5935]: https://ferlab-crsj.atlassian.net/browse/CLIN-5935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ