### PR TITLE
feat: CLIN-4440 import COSMIC files deposited manually instead of downloading them

### DIFF
--- a/dags/etl_import_cosmic.py
+++ b/dags/etl_import_cosmic.py
@@ -1,16 +1,17 @@
-import base64
+# import base64
 from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
+from airflow.exceptions import AirflowFailException
 from airflow.utils.trigger_rule import TriggerRule
-from lib import config
+# from lib import config
 from lib.config import K8sContext, config_file
 from lib.operators.spark import SparkOperator
 from lib.operators.trigger_dagrun import TriggerDagRunOperator
 from lib.slack import Slack
 from lib.tasks.public_data import PublicSourceDag, update_public_data_info, should_continue
-from lib.utils import http_get
+# from lib.utils import http_get
 
 
 cosmic_dag = PublicSourceDag(
@@ -31,30 +32,50 @@ with DAG(
 
     @task(task_id='files', on_execute_callback=Slack.notify_dag_start)
     def files():
-        url = 'https://cancer.sanger.ac.uk/cosmic'
-        path = 'file_download/GRCh38/cosmic'
-
-        # TODO: Download Cosmic_CancerGeneCensus_GRCh38.tar when scripted downloads are added to new download page
+        # COSMIC downloads are no longer automated: the licence is bound to a named user and to
+        # their IP, so no service account can fetch the archives. The files are deposited by hand
+        # under raw/landing/cosmic/ (cmc_export.tsv.gz, Cosmic_CancerGeneCensus_GRCh38.tsv.gz),
+        # and the version marker cosmic.version is updated by hand along with them.
+        #
+        # The download code is kept below for the day scripted downloads become available again.
+        # Note that the gene census file name below is stale: the ETL reads
+        # Cosmic_CancerGeneCensus_GRCh38.tsv.gz, not cancer_gene_census.csv.
+        #
+        # url = 'https://cancer.sanger.ac.uk/cosmic'
+        # path = 'file_download/GRCh38/cosmic'
+        #
         # gene_census_file = 'cancer_gene_census.csv'
-        mutation_census_file = 'cmc_export.tsv.gz'
-        mutation_census_archive = 'CMC.tar'
+        # mutation_census_file = 'cmc_export.tsv.gz'
+        # mutation_census_archive = 'CMC.tar'
+        #
+        # # Get latest version
+        # cosmic_dag.set_last_version_from_url(url, 'COSMIC (v[0-9]+),')
+        #
+        # for file_name in [mutation_census_file]:
+        #     # Encode credentials
+        #     headers = {'Authorization': f'Basic {base64.b64encode(config.cosmic_credentials.encode()).decode()}'}
+        #
+        #     # Get file url
+        #     download_url = http_get(
+        #         f'{url}/{path}/{cosmic_dag.last_version}/{mutation_census_archive if file_name == mutation_census_file else file_name}',
+        #         headers=headers
+        #     ).json()['url']
+        #
+        #     # Upload file to S3 (if new)
+        #     cosmic_dag.upload_file_if_new(download_url, file_name, headers=headers, tar_extract=mutation_census_file if file_name == mutation_census_file else None)
 
-        # Get latest version
-        # TODO: Cosmic need an account to access the download page: https://ferlab-crsj.atlassian.net/browse/CLIN-4440
-        cosmic_dag.set_last_version_from_url(url, 'COSMIC (v[0-9]+),')
+        deposited_version = cosmic_dag.get_current_version()
+        if not deposited_version:
+            raise AirflowFailException(
+                f'No version found in s3://{cosmic_dag.s3_bucket}/{cosmic_dag.s3_key}/{cosmic_dag.name}.version. '
+                f'Deposit the COSMIC files and write the version they correspond to in that file '
+                f'before running this DAG.'
+            )
 
-        for file_name in [mutation_census_file]:
-            # Encode credentials
-            headers = {'Authorization': f'Basic {base64.b64encode(config.cosmic_credentials.encode()).decode()}'}
-
-            # Get file url
-            download_url = http_get(
-                f'{url}/{path}/{cosmic_dag.last_version}/{mutation_census_archive if file_name == mutation_census_file else file_name}',
-                headers=headers
-            ).json()['url']
-            
-            # Upload file to S3 (if new)
-            cosmic_dag.upload_file_if_new(download_url, file_name, headers=headers, tar_extract=mutation_census_file if file_name == mutation_census_file else None)
+        # The marker is maintained by hand, so it cannot be compared against itself: the reference
+        # for 'already imported' is the version published by the last successful run of this DAG.
+        cosmic_dag.set_last_version(deposited_version)
+        cosmic_dag.is_new_version = deposited_version != cosmic_dag.get_published_version()
 
         return cosmic_dag
 

--- a/dags/lib/tasks/public_data.py
+++ b/dags/lib/tasks/public_data.py
@@ -156,6 +156,15 @@ class PublicSourceDag:
         return version
 
 
+    def get_published_version(self) -> str:
+        """Version recorded by the last successful run of this DAG (written by update_public_data_info).
+
+        Useful for manually deposited sources, where the S3 version marker is maintained by hand
+        and therefore cannot serve as the 'already imported' reference.
+        """
+        return next((entry.version for entry in _get_public_data_json() if entry.dag_id == self.dag_id), None)
+
+
     def set_last_version(self, version: str, version_key: str = None):
         if version_key:
             current_version = self.get_current_version()


### PR DESCRIPTION
## 📌 Context

Le téléchargement automatique de COSMIC n'est plus possible : la licence est désormais
nominative et liée à l'IP du détenteur, donc aucun compte de service ne peut récupérer
les archives. Les fichiers sont maintenant déposés à la main dans S3, et le DAG est
lancé manuellement.

Le DAG conserve son rôle : détecter qu'une nouvelle version est disponible, lancer les
deux imports Spark, déclencher `etl_import_genes` et publier la version dans
`public-databases.json`.

## 📝 Changes

- `etl_import_cosmic` : le code de téléchargement est commenté (et non supprimé) pour
  pouvoir être réactivé si les téléchargements scriptés redeviennent possibles.
- La version n'est plus scrapée sur le site de Cosmic : elle est lue dans le marqueur
  S3 `raw/landing/cosmic/cosmic.version`, mis à jour à la main avec les fichiers.
- Échec explicite (`AirflowFailException`) si ce marqueur est absent : sans version
  déclarée, aucun import ne doit partir.
- `PublicSourceDag.get_published_version()` : nouvelle méthode qui lit la version
  enregistrée par le dernier run réussi dans `public-databases.json`.

`should_continue` est inchangé et garde le comportement des autres DAGs d'import.

### Pourquoi une deuxième source de version

`check_is_new_version()` compare `cosmic.version` à `last_version`. Le marqueur étant
maintenant maintenu à la main, il ne peut pas être comparé à lui-même — sinon le DAG
serait skippé indéfiniment. La référence « déjà importé » devient donc la version
publiée dans `public-databases.json`, écrite uniquement par `update_public_data_info`
en fin de run réussi.

| Fichier | Rôle | Écrit par |
|---|---|---|
| `raw/landing/cosmic/cosmic.version` | version déposée, disponible à importer | l'opérateur, à la main |
| `public-databases.json` → `version` | version importée au dernier run réussi | `update_public_data_info` |

## ☑️ TO-DOs

- [ ] Décider du sort de `cosmic_credentials` (`dags/lib/config.py`), désormais inutilisé —
      conservé pour l'instant en vue d'une réactivation du téléchargement.

## 🧪 Tests

Aucun test ajouté : `dags/lib/tasks/public_data.py` n'a pas de couverture existante, et
`get_published_version()` demanderait un bucket `cqgc-test-app-public` absent de
`all_qlin_buckets`. `tests/dags/test_dags.py` couvre l'import du DAG modifié.

## ✅ QA

### Steps to validate

1. Déposer les fichiers COSMIC dans `s3://cqgc-<env>-app-datalake/raw/landing/cosmic/`
   (`cmc_export.tsv.gz`, `Cosmic_CancerGeneCensus_GRCh38.tsv.gz`) et écrire la version
   correspondante dans `cosmic.version` (format préfixé, ex. `v104`).
2. Lancer `etl_import_cosmic` : `files` passe au vert sans rien télécharger, puis
   `gene_table` et `mutation_table` s'exécutent, `etl_import_genes` est déclenché, et
   `public-databases.json` affiche la nouvelle version.
3. Relancer le DAG sans toucher `cosmic.version` : `should_continue` court-circuite,
   les tâches en aval sont skippées (non-régression du comportement d'origine).
4. Relancer avec `skip_if_not_new_version = no` : le DAG s'exécute malgré la version
   inchangée, comme sur les autres DAGs d'import.
5. Vider ou supprimer `cosmic.version` et lancer le DAG : `files` échoue avec le chemin
   S3 attendu dans le message d'erreur.

## 🔗 Related Issues

- [JIRA](https://ferlab-crsj.atlassian.net/browse/CLIN-4440)

## 👀 Notes for Reviewers

- L'ajout à `PublicSourceDag` est purement additif : aucun autre DAG n'appelle
  `get_published_version()`, donc pas d'impact sur les ~20 autres imports publics.
- Le nom de fichier `cancer_gene_census.csv` dans le code commenté est périmé — l'ETL lit
  `Cosmic_CancerGeneCensus_GRCh38.tsv.gz`. Signalé en commentaire pour éviter qu'il soit
  réactivé tel quel.
- Hors scope, à traiter séparément : ni `etl_import_cosmic` ni `etl_import_genes` ne
  propagent jusqu'à Elasticsearch. Après un import, le portail continue d'afficher les
  données de la version précédente jusqu'à ce que la chaîne
  `enrich.variants` → `prepare_index.variant_centric` → `index` → `publish` soit lancée
  à la main (cf. le task group `enrich_and_index` de `etl_import_panels`).
