### PR TITLE
fix: CLIN-4440 move public-databases.json registration to a dedicated DAG

### DIFF
--- a/dags/init_public_databases_file.py
+++ b/dags/init_public_databases_file.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from airflow import DAG
+
+from lib.tasks.public_data import (PublicSourceDag, get_schedule_by_env,
+                                   init_public_databases_dag_id, sync_public_databases_file)
+
+
+with DAG(
+    dag_id=init_public_databases_dag_id,
+    start_date=datetime(2026, 7, 31),
+    # Daily, ahead of the scheduled public source imports (the earliest is ClinVar at 6am) so a
+    # source added or renamed by a deployment is registered before its next run.
+    schedule=get_schedule_by_env('0 5 * * *'),
+    default_args=PublicSourceDag.default_args,
+    catchup=False,
+    max_active_runs=1,
+) as dag:
+
+    sync_public_databases_file()

--- a/dags/lib/tasks/public_data.py
+++ b/dags/lib/tasks/public_data.py
@@ -2,13 +2,13 @@ import json
 import logging
 import re
 import ast
-import sys
 import tarfile
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, ClassVar
 from airflow.decorators import task
-from airflow.models import DagRun
+from airflow.models import DagBag, DagRun
 from airflow.models.param import Param
 from airflow.operators.python import ShortCircuitOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -19,14 +19,17 @@ from lib.config import env
 from lib.slack import Slack
 from lib.utils import http_get
 from lib.utils_s3 import get_s3_file_version, http_get_file, stream_upload_or_resume_to_s3, file_md5
-from multiprocessing import Lock
 
 
 s3 = S3Hook(config.s3_conn_id)
 s3_public_bucket = f'cqgc-{env}-app-public'
 s3_public_data_file_key = 'public-databases.json'
+init_public_databases_dag_id = 'init_public_databases_file'
 
-lock = Lock()
+# This module lives in <dags>/lib/tasks/, so the DAG files are two levels up. Preferred over
+# airflow.settings.DAGS_FOLDER, which points at the Airflow config and not at this checkout.
+dags_folder = Path(__file__).parents[2]
+
 
 @dataclass
 class PublicSourceInfo:
@@ -69,6 +72,10 @@ def _get_public_data_json() -> list[PublicSourceInfo]:
 
 class PublicSourceDag:
     __version__: ClassVar[int] = 1
+    # Every source declared by a DAG file imported in the current process, keyed by dag_id. A worker
+    # only imports the file holding the task it was given, so a reader has to load the DagBag first
+    # — see sync_public_databases_file.
+    _registered: ClassVar[dict[str, 'PublicSourceDag']] = {}
     params={
         'skip_if_not_new_version': Param('yes', enum=['yes', 'no']),
     }
@@ -98,8 +105,16 @@ class PublicSourceDag:
         self.schedule = get_schedule_by_env(schedule)
         self.last_version = last_version
         self.is_new_version = is_new_version
-        if add_to_file and "pytest" not in sys.modules: # Disable this section for tests (s3 config does not exist)
-            self._addpublic_source_to_data_file()
+        # False for the sources deliberately kept out of the file (gnomAD constraint/CNV/SV, HPO
+        # terms), and when deserialize() rehydrates an instance from XCom — the latter is not a
+        # declaration, and since serialize() drops 'schedule' it would register a null frequency.
+        if add_to_file:
+            PublicSourceDag._registered[self.dag_id] = self
+
+
+    @classmethod
+    def registered(cls) -> list['PublicSourceDag']:
+        return list(cls._registered.values())
 
 
     def serialize(self) -> dict[str, Any]:
@@ -128,26 +143,6 @@ class PublicSourceDag:
             frequency= self.schedule
         )
     
-
-    def _addpublic_source_to_data_file(self):
-        source_info = _init_last_update(self.get_info())
-        public_sources = _get_public_data_json()
-        exist = False
-        for entry in public_sources:
-            if entry.dag_id == self.dag_id:
-                entry.source = source_info.source
-                entry.url = source_info.url
-                entry.frequency = source_info.frequency
-                exist = True
-                break
-
-        # The lock is automatically acquired and released when the with block is exited
-        with lock:
-            if not exist:
-                public_sources.append(source_info)
-            s3.load_string(_public_sources_to_json(public_sources), s3_public_data_file_key, s3_public_bucket, replace=True)
-            logging.info(f"PublicSource entry '{self.dag_id}' added to '{s3_public_data_file_key}'")
-
 
     def get_current_version(self, version_key: str = None) -> str:
         version = get_s3_file_version(s3, self.s3_bucket, f'{self.s3_key}/{self.name}')
@@ -249,24 +244,73 @@ class PublicSourceDag:
 
 @task(task_id='update_public_data_info', trigger_rule=TriggerRule.NONE_FAILED, on_success_callback=Slack.notify_dag_completion)
 def update_public_data_info(dag_data: PublicSourceDag, **context):
-    # The lock is automatically acquired and released when the with block is exited
-    with lock:
-        dag_id = context['dag'].dag_id
-        version = dag_data.last_version
-        logging.info(f"Updating public data info for dag '{dag_id}' with version '{version}'")
-        # Check if the entry already exists
-        public_sources = _get_public_data_json()
-        for entry in public_sources:
-            if entry.dag_id == dag_id:
-                entry.lastUpdate = datetime.now().isoformat()
-                entry.version = version if version else entry.version
-                entry.frequency = context['dag'].schedule_interval if context['dag'].schedule_interval else ""
-                break
-        else:
-            raise Exception(f"PublicSource entry '{dag_id}' not found")
+    """Publish the run outcome. Owns 'version' and 'lastUpdate'.
 
-        # Save to S3
-        s3.load_string(_public_sources_to_json(public_sources), s3_public_data_file_key, s3_public_bucket, replace=True)
+    'source', 'url' and 'frequency' belong to sync_public_databases_file and are only written here
+    to create a missing entry, so that a source added between two of its runs does not fail its
+    first import.
+    """
+    dag = context['dag']
+    version = dag_data.last_version
+    logging.info(f"Updating public data info for dag '{dag.dag_id}' with version '{version}'")
+
+    public_sources = _get_public_data_json()
+    entry = next((e for e in public_sources if e.dag_id == dag.dag_id), None)
+    if entry is None:
+        logging.warning(f"PublicSource entry '{dag.dag_id}' not found, creating it — "
+                        f"'{init_public_databases_dag_id}' has not run since this source was added")
+        entry = dag_data.get_info()
+        # serialize() drops 'schedule', so a dag_data rehydrated from XCom cannot supply the
+        # frequency. The DAG is built with the source's own schedule, so its interval is the
+        # same value sync_public_databases_file would write.
+        entry.frequency = dag.schedule_interval
+        public_sources.append(entry)
+
+    entry.lastUpdate = datetime.now().isoformat()
+    entry.version = version if version else entry.version
+
+    # Save to S3
+    s3.load_string(_public_sources_to_json(public_sources), s3_public_data_file_key, s3_public_bucket, replace=True)
+
+
+@task(task_id='sync_public_databases_file')
+def sync_public_databases_file():
+    """Register every public source and refresh 'source', 'url' and 'frequency'.
+
+    Single writer for those three fields: doing it at DAG parse time meant a read-modify-write on
+    this one S3 object on every parse cycle of every DAG file, racing with the 'version' /
+    'lastUpdate' published by update_public_data_info.
+    """
+    # Loading the DagBag executes every DAG file in this process, which is what fills the registry
+    # — a worker otherwise only imports the file holding the task it was given.
+    dag_bag = DagBag(dag_folder=str(dags_folder), include_examples=False)
+    if dag_bag.import_errors:
+        logging.warning(f'DAG files failed to import, their sources may be missing: '
+                        f'{sorted(dag_bag.import_errors)}')
+
+    sources = PublicSourceDag.registered()
+    logging.info(f'{len(sources)} public sources registered: {sorted(s.dag_id for s in sources)}')
+
+    public_sources = _get_public_data_json()
+    by_dag_id = {entry.dag_id: entry for entry in public_sources}
+    added, refreshed = [], []
+
+    for source in sources:
+        entry = by_dag_id.get(source.dag_id)
+        metadata = (source.display_name, source.website, source.schedule)
+        if entry is None:
+            public_sources.append(_init_last_update(source.get_info()))
+            added.append(source.dag_id)
+        elif (entry.source, entry.url, entry.frequency) != metadata:
+            entry.source, entry.url, entry.frequency = metadata
+            refreshed.append(source.dag_id)
+
+    if not added and not refreshed:
+        logging.info(f"'{s3_public_data_file_key}' already up to date")
+        return
+
+    s3.load_string(_public_sources_to_json(public_sources), s3_public_data_file_key, s3_public_bucket, replace=True)
+    logging.info(f"'{s3_public_data_file_key}' saved — added: {added}, refreshed: {refreshed}")
 
 
 def should_continue(dag_data: PublicSourceDag):

--- a/tests/lib/tasks/test_public_data.py
+++ b/tests/lib/tasks/test_public_data.py
@@ -1,0 +1,174 @@
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest import mock
+
+MODULE = 'lib.tasks.public_data'
+
+
+def test_every_published_source_is_registered():
+    """A published source missing from the registry would be missing from public-databases.json, and
+    its first run would then fall back to creating its own entry. Sources opting out with
+    add_to_file=False (gnomAD constraint / CNV / SV, HPO terms) must stay out."""
+    from airflow.models import DagBag
+    from lib.tasks.public_data import PublicSourceDag, dags_folder
+
+    DagBag(dag_folder=str(dags_folder), include_examples=False)
+
+    published, opted_out = set(), set()
+    for path in dags_folder.glob('etl_import_*.py'):
+        declaration = path.read_text()
+        if 'PublicSourceDag(' in declaration:
+            (opted_out if 'add_to_file=False' in declaration else published).add(path.stem)
+
+    registered = {source.dag_id for source in PublicSourceDag.registered()}
+
+    assert published, 'no DAG file declares a published PublicSourceDag — the glob is wrong'
+    assert published <= registered
+    assert not opted_out & registered
+
+
+def _source(name='cosmic', display_name='COSMIC', website='https://www.cosmickb.org/', **kwargs):
+    from lib.tasks.public_data import PublicSourceDag
+    return PublicSourceDag(name=name, display_name=display_name, website=website,
+                           add_to_file=False, **kwargs)
+
+
+def _entry(**kwargs):
+    from lib.tasks.public_data import PublicSourceInfo
+    defaults = {
+        'dag_id': 'etl_import_cosmic',
+        'source': 'COSMIC',
+        'url': 'https://www.cosmickb.org/',
+        'version': 'v104',
+        'lastUpdate': '2026-07-30T15:12:03.123456',
+        'frequency': None,
+    }
+    return PublicSourceInfo(**{**defaults, **kwargs})
+
+
+@contextmanager
+def _mocked_sync(sources, entries, current_version='v104'):
+    """Isolate sync_public_databases_file from S3 and from the real DagBag."""
+    from lib.tasks.public_data import PublicSourceDag
+    for source in sources:
+        source.get_current_version = mock.Mock(return_value=current_version)
+    with mock.patch(f'{MODULE}.s3') as s3, \
+            mock.patch(f'{MODULE}.DagBag') as dag_bag, \
+            mock.patch(f'{MODULE}._get_public_data_json', return_value=entries), \
+            mock.patch(f'{MODULE}._init_last_update', side_effect=lambda info: info) as init_last_update, \
+            mock.patch.object(PublicSourceDag, 'registered', return_value=sources):
+        dag_bag.return_value.import_errors = {}
+        yield SimpleNamespace(s3=s3, init_last_update=init_last_update)
+
+
+def _sync(sources, entries, current_version='v104'):
+    from lib.tasks.public_data import sync_public_databases_file
+    with _mocked_sync(sources, entries, current_version) as m:
+        sync_public_databases_file.function()
+    return m
+
+
+def _written(s3) -> list[dict]:
+    s3.load_string.assert_called_once()
+    return json.loads(s3.load_string.call_args.args[0])
+
+
+def test_sync_does_not_write_when_nothing_changed():
+    """Runs daily: an unconditional rewrite would race with the version / lastUpdate published by
+    update_public_data_info."""
+    source = _source()
+
+    m = _sync([source], [_entry()])
+
+    m.s3.load_string.assert_not_called()
+    source.get_current_version.assert_not_called()
+    m.init_last_update.assert_not_called()
+
+
+def test_sync_writes_once_for_a_legacy_empty_frequency():
+    """update_public_data_info used to write "" where the sync writes None; the first run after the
+    fix normalizes it, and the next one is a no-op."""
+    source = _source()
+    entries = [_entry(frequency='')]
+
+    m = _sync([source], entries)
+    assert _written(m.s3)[0]['frequency'] is None
+
+    m = _sync([source], entries)
+    m.s3.load_string.assert_not_called()
+
+
+def test_sync_refreshes_metadata_without_touching_the_published_run():
+    source = _source()
+
+    m = _sync([source], [_entry(url='https://cancer.sanger.ac.uk/cosmic')])
+
+    written = _written(m.s3)[0]
+    assert written['url'] == 'https://www.cosmickb.org/'
+    assert written['version'] == 'v104'
+    assert written['lastUpdate'] == '2026-07-30T15:12:03.123456'
+
+
+def test_sync_appends_a_missing_source():
+    source = _source()
+
+    m = _sync([source], [_entry(dag_id='etl_import_clinvar', source='NCBI Clinvar')],
+              current_version='v105')
+
+    written = _written(m.s3)
+    assert [e['dag_id'] for e in written] == ['etl_import_clinvar', 'etl_import_cosmic']
+    assert written[1]['version'] == 'v105'
+    m.init_last_update.assert_called_once()
+
+
+def test_sync_writes_the_whole_file_once():
+    """The point of the DAG: one write for every source, not one read-modify-write per source."""
+    sources = [_source(), _source(name='clinvar', display_name='NCBI Clinvar', website='https://ncbi')]
+
+    m = _sync(sources, [_entry(url='stale'), _entry(dag_id='etl_import_clinvar', source='stale')])
+
+    written = _written(m.s3)
+    assert [e['dag_id'] for e in written] == ['etl_import_cosmic', 'etl_import_clinvar']
+    assert [e['source'] for e in written] == ['COSMIC', 'NCBI Clinvar']
+
+
+def test_update_public_data_info_publishes_only_the_run_outcome():
+    """The task owns version / lastUpdate: writing frequency here is what used to make the two
+    writers disagree on an empty schedule and rewrite the file forever."""
+    from lib.tasks.public_data import update_public_data_info
+    entries = [_entry(version='v103')]
+    dag_data = _source(last_version='v104')
+    context = {'dag': SimpleNamespace(dag_id='etl_import_cosmic', schedule_interval='0 6 * * 6')}
+
+    with mock.patch(f'{MODULE}.s3') as s3, \
+            mock.patch(f'{MODULE}._get_public_data_json', return_value=entries):
+        update_public_data_info.function(dag_data, **context)
+
+    written = _written(s3)[0]
+    assert written['version'] == 'v104'
+    assert written['lastUpdate'] != '2026-07-30T15:12:03.123456'
+    assert written['frequency'] is None
+    assert written['source'] == 'COSMIC'
+    assert written['url'] == 'https://www.cosmickb.org/'
+
+
+def test_update_public_data_info_creates_a_missing_entry():
+    """A source added between two runs of the init DAG must not fail its first import."""
+    from lib.tasks.public_data import update_public_data_info
+    entries = [_entry(dag_id='etl_import_clinvar', source='NCBI Clinvar')]
+    dag_data = _source(last_version='v104')
+    dag_data.get_current_version = mock.Mock(return_value='v104')
+    context = {'dag': SimpleNamespace(dag_id='etl_import_cosmic', schedule_interval='0 6 * * 6')}
+
+    with mock.patch(f'{MODULE}.s3') as s3, \
+            mock.patch(f'{MODULE}._get_public_data_json', return_value=entries):
+        update_public_data_info.function(dag_data, **context)
+
+    written = _written(s3)[1]
+    assert written['dag_id'] == 'etl_import_cosmic'
+    assert written['source'] == 'COSMIC'
+    assert written['version'] == 'v104'
+    assert written['lastUpdate']
+    # serialize() drops 'schedule', so the frequency comes from the DAG's own interval
+    assert written['frequency'] == '0 6 * * 6'


### PR DESCRIPTION
## 📌 Context

Every DAG file declaring a `PublicSourceDag` wrote `public-databases.json` at import time. Airflow re-imports DAG files every 30 s, and every worker re-imports one to start a task — so that was tens of read-modify-writes per minute on a single S3 object, to refresh 3 fields that only change on a deployment. `lock` was a `multiprocessing.Lock` created at import, one per process, synchronizing nothing: a parse that read the file before `update_public_data_info` published its `version` / `lastUpdate`, and wrote after, reverted them. For `etl_import_cosmic` that is the reference `get_published_version()` uses to skip a re-import.

## 📝 Changes

- New DAG `init_public_databases_file` — daily at 5am (ahead of the Saturday imports, earliest is ClinVar at 6am), also triggerable manually with no params. Its single task writes the whole file once.
- `PublicSourceDag.__init__` no longer touches S3: it registers the source in a class-level registry. `add_to_file=False` keeps its meaning — the 4 sources deliberately excluded (gnomAD constraint / CNV / SV, HPO terms) stay out, and a `dag_data` rehydrated from XCom doesn't register.
- `sync_public_databases_file` loads the `DagBag`, which runs every DAG file in its own process and is what fills the registry — a worker otherwise only imports the file holding its task. Import errors are logged instead of failing the sync.
- `update_public_data_info` publishes `version` / `lastUpdate` only, and upserts instead of raising, so a source added between two syncs doesn't fail its first import. It no longer writes `frequency`: it wrote `""` where the sync writes `None`, so the two writers never agreed.
- `lock` and the `"pytest" not in sys.modules` guard removed — no import-time side effect left to disable.

## 🧪 Tests

`tests/lib/tasks/test_public_data.py` — 8 tests: registry coverage (16 published in, 4 opted out), the sync's no-op path (no write, no S3 marker read, no `DagRun` query), the `""` → `None` migration, metadata refresh preserving the published run, append of a missing source, a single write for all sources, and both `update_public_data_info` paths.

## ✅ QA

### Steps to validate

1. After deploy, `s3://cqgc-<env>-app-public/public-databases.json` stops changing on its own — `LastModified` must no longer move between DAG runs.
2. Trigger `init_public_databases_file` manually: it succeeds and the task log lists the 16 registered sources. A second run right after writes nothing (`already up to date`).
3. Trigger `etl_import_cosmic` → its entry gets the new `version` + `lastUpdate`, still there minutes later.
4. Non-regression: `etl_import_clinvar` keeps its `frequency` (`0 6 * * 6` in prod, shifted in qa/staging), `source` and `url`.
5. The portal's public-databases page still lists the 16 published sources.

## 🔗 Related Issues

- [JIRA](https://ferlab-crsj.atlassian.net/browse/CLIN-4440)

## 👀 Notes for Reviewers

- Not CLIN-4440's subject; reuses the branch whose PR #937 is merged.
- Trade-off: a source added or renamed now appears at the next sync (up to 24 h) instead of within 30 s. The daily schedule, the manual trigger and the upsert cover it.
- The race is rare, not closed: the single daily write could still overwrite a `version` published in the same instant. A real compare-and-swap needs `put_object(IfMatch=<etag>)`, which `S3Hook.load_string` doesn't expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
